### PR TITLE
[Feat]: support marking static shapes along with dynamic shapes in magi_compile

### DIFF
--- a/magi_compiler/_api.py
+++ b/magi_compiler/_api.py
@@ -103,8 +103,8 @@ def _run_orchestration(state: MagiCompileState, original_invoker, args, kwargs):
     # First compilation
     state._ensure_compiled()
 
-    # Mark dynamic shapes
-    _mark_dynamic_shapes(state, args, kwargs)
+    # Mark dynamic and static shapes
+    _apply_shape_marks(state, args, kwargs)
 
     magi_logger.info(f"Start compiling function {state.original_code_object}")
     torch._dynamo.eval_frame.remove_from_cache(state.original_code_object)
@@ -312,9 +312,9 @@ def _resolve_nested_arg(bound_args: inspect.BoundArguments, key: str):
     return arg
 
 
-def _mark_dynamic_shapes(state: MagiCompileState, args, kwargs):
+def _apply_shape_marks(state: MagiCompileState, args, kwargs):
     """
-    Manually mark dynamic dimensions for arguments specified in dynamic_arg_dims.
+    Main entry point for applying dynamic and static shape marks.
 
     This is called just before Dynamo tracing to ensure dimensions are
     correctly generalized in the captured graph.
@@ -322,14 +322,74 @@ def _mark_dynamic_shapes(state: MagiCompileState, args, kwargs):
     sig = inspect.signature(state._target_callable)
     bound = sig.bind(*args, **kwargs)
     bound.apply_defaults()
+
+    dynamic_records = _mark_dynamic_shapes(state, bound)
+
+    _mark_static_shapes(bound, dynamic_records)
+
+
+def _mark_dynamic_shapes(state: MagiCompileState, bound):
+    """
+    Manually mark dynamic dimensions for arguments specified in dynamic_arg_dims.
+    """
+    dynamic_records = {}
+
     for k, dims in state.dynamic_arg_dims.items():
         arg = _resolve_nested_arg(bound, k)
         if arg is None:
             continue
+
         dims = [dims] if isinstance(dims, int) else dims
         assert isinstance(arg, torch.Tensor), f"Expected tensor for {k}, got {type(arg)}"
+
         final_dims = [arg.ndim + d if d < 0 else d for d in dims]
+
         torch._dynamo.mark_dynamic(arg, final_dims)
+
+        dynamic_records[id(arg)] = set(final_dims)
+
+    return dynamic_records
+
+
+def _mark_static_shapes(bound, dynamic_records):
+    """
+    Mark static dimensions for tensors that are not marked as dynamic,
+    dynamic_records is a dictionary that maps the id of the tensor to the set of dynamic dimensions.
+    """
+    visited = set()
+
+    def traverse_and_mark(obj):
+        obj_id = id(obj)
+        if obj_id in visited or isinstance(obj, (int, float, str, bool, type(None))):
+            return
+        visited.add(obj_id)
+
+        if isinstance(obj, torch.Tensor):
+            dyn_dims = dynamic_records.get(obj_id, set())
+            for dim_idx in range(obj.ndim):
+                if dim_idx not in dyn_dims:
+                    torch._dynamo.mark_static(obj, dim_idx)
+            return
+
+        if isinstance(obj, (list, tuple, set)):
+            for item in obj:
+                traverse_and_mark(item)
+
+        elif isinstance(obj, dict):
+            for val in obj.values():
+                traverse_and_mark(val)
+
+        elif hasattr(obj, '__dict__'):
+            for val in vars(obj).values():
+                traverse_and_mark(val)
+
+        elif hasattr(obj, '__slots__'):
+            for slot in obj.__slots__:
+                if hasattr(obj, slot):
+                    traverse_and_mark(getattr(obj, slot))
+
+    for arg_val in bound.arguments.values():
+        traverse_and_mark(arg_val)
 
 
 @contextmanager

--- a/magi_compiler/magi_backend/magi_compiler_base.py
+++ b/magi_compiler/magi_backend/magi_compiler_base.py
@@ -28,7 +28,7 @@ import torch
 from magi_compiler.config import CompileConfig, model_rank_dir_name
 from magi_compiler.magi_backend.magi_backend import init_backend
 from magi_compiler.magi_depyf.timeline import emit_after_dynamo_bytecode_transform, observe_lifecycle
-from magi_compiler.utils import OrderedSet, compute_code_hash, compute_hash, envs, magi_logger
+from magi_compiler.utils import OrderedSet, compute_code_hash, compute_hash, magi_logger
 
 
 def _source_meta_path(aot_path: str) -> str:
@@ -143,7 +143,7 @@ class MagiCompileState:
         # delegates to ``torch._dynamo.aot_compile.aot_compile_fullgraph``
         # (aot_compile.py:108).
         self._compiled_callable = torch.compile(
-            self._target_callable, fullgraph=True, dynamic=envs.MAGI_DYNAMIC_COMPILE, backend=backend, options=options
+            self._target_callable, fullgraph=True, dynamic=True, backend=backend, options=options
         )
 
     @property

--- a/magi_compiler/utils/envs.py
+++ b/magi_compiler/utils/envs.py
@@ -54,5 +54,3 @@ MAGI_SHARED_BIN_PATH = "/dev/shm"
 
 # Logging level for MagiCompiler (DEBUG / INFO / WARNING / ERROR). Read once at import time.
 MAGI_LOGGING_LEVEL: str = os.getenv("MAGI_LOGGING_LEVEL", "WARNING").upper()
-
-MAGI_DYNAMIC_COMPILE: bool = _env_to_bool("MAGI_DYNAMIC_COMPILE", default=True)


### PR DESCRIPTION
- Introduce `_apply_shape_marks` as the main entry point to apply both dynamic and static shapes before Dynamo tracing.
- Refactor `_mark_dynamic_shapes` to mark args dynamic and return records of marked dynamic dimensions.
- Add `_mark_static_shapes` to recursively traverse function arguments and explicitly mark all remaining un-marked tensor dimensions as static using `torch._dynamo.mark_static`.