### PR TITLE
chore: upgrade GitHub Actions workflows for Node 24 migration

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -37,7 +37,7 @@ jobs:
                 git config --global https.proxy "${{ secrets.HTTPS_PROXY }}"
 
         -   name: Checkout base branch
-            uses: actions/checkout@v4
+            uses: actions/checkout@v6
             timeout-minutes: 5
             with:
                 ref: ${{ github.event.pull_request.base.sha }}
@@ -45,7 +45,7 @@ jobs:
                 persist-credentials: false
 
         -   name: Checkout PR head
-            uses: actions/checkout@v4
+            uses: actions/checkout@v6
             timeout-minutes: 5
             with:
                 ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         -   name: Validate PR body
-            uses: actions/github-script@v7
+            uses: actions/github-script@v8
             with:
                 script: |
                     const body = context.payload.pull_request.body;


### PR DESCRIPTION
## 🗂️ PR Category
- [ ] ✨ New Feature
- [ ] 🚀 Optimization (performance, memory, etc.)
- [ ] 💥 Breaking Change
- [ ] 🐛 Bug Fix
- [ ] 🛠️ Development / Refactoring
- [ ] 📚 Documentation
- [x] 🧹 Chore (Dependencies, CI/CD, Configuration, etc.)
- [ ] 🧪 Testing

## 📝 Description

This PR updates GitHub Actions versions in our workflows to align with GitHub's Node 24 migration plan for JavaScript-based actions.

Changes in this PR:
- Upgrade `actions/checkout` from `v4` to `v6` in [`integration_test.yml`](./.github/workflows/integration_test.yml)
- Upgrade `actions/github-script` from `v7` to `v8` in [`pr-description-check.yml`](./.github/workflows/pr-description-check.yml)

Why this change is needed:
- GitHub announced the deprecation of Node 20 on GitHub Actions runners on September 19, 2025.
- GitHub later updated the migration timeline on February 25, 2026, and stated that runners will begin using Node 24 by default on June 2, 2026.
- GitHub explicitly recommends that Actions users update workflows to the latest versions of actions that run on Node 24.

Impact on this repository:
- This PR is intended to be a runtime/version upgrade only.
- No workflow logic is changed.
- The self-hosted runner version currently in use is `2.333.1`, which is new enough for `actions/checkout@v6`.

Validation:
- `pre-commit run --all-files` passed
- Git commit hooks passed during commit creation

Reference:
- GitHub Changelog: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
