### PR TITLE
fix(build): add versioningit to build requirements

### DIFF
--- a/magi_compiler/__init__.py
+++ b/magi_compiler/__init__.py
@@ -14,4 +14,9 @@
 
 from .api import magi_compile, magi_register_custom_op
 
-__all__ = ["magi_compile", "magi_register_custom_op"]
+try:
+    from ._version import __version__
+except ModuleNotFoundError:
+    __version__ = "0.0.0+unknown"
+
+__all__ = ["magi_compile", "magi_register_custom_op", "__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ profile = "black"
 requires = [
     "setuptools>=61.0",
     "wheel",
+    "versioningit",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
## 🗂️ PR Category
- [ ] ✨ New Feature
- [ ] 🚀 Optimization (performance, memory, etc.)
- [ ] 💥 Breaking Change
- [ ] 🐛 Bug Fix
- [ ] 🛠️ Development / Refactoring
- [ ] 📚 Documentation
- [x] 🧹 Chore (Dependencies, CI/CD, Configuration, etc.)
- [ ] 🧪 Testing

## 📝 Description

This fix ensures that installing the package via `pip install .` correctly generates `magi_compiler/_version.py` with the resolved version, and exposes that version through `magi_compiler.__version__` after import.

<img width="878" height="174" alt="image" src="https://github.com/user-attachments/assets/340ef294-b401-4918-b2bb-10b7d600a7dd" />
