### PR TITLE
[Perf] Reduce magi_compile dispatch overhead to match torch.compile parity

### DIFF
--- a/magi_compiler/_api.py
+++ b/magi_compiler/_api.py
@@ -85,14 +85,31 @@ def _run_orchestration(state: MagiCompileState, args, kwargs):
     """
     Central orchestration logic for magi_compile.
 
-    Handles the logic for:
+    Dispatch order:
+    0. NONE / TORCH_COMPILE — short-circuit before any magi logic.
     1. JIT Fast Path: If bytecode is already captured, swap and run.
     2. AOT Fast Path: If AOT artifacts exist, load, swap, and run.
-    3. First-time Compilation:
+    3. First-time Compilation (MAGI_COMPILE only):
        - Run Dynamo tracing/compilation.
        - Capture compiled bytecode (for future JIT fast path).
        - (Optional) Perform AOT compilation and save artifacts.
     """
+    compile_mode = state.compile_config.compile_mode
+
+    if compile_mode == CompileMode.NONE:
+        return state.original_entry(*args, **kwargs)
+
+    if compile_mode == CompileMode.TORCH_COMPILE:
+        if state.compiled_entry is None:
+            state._ensure_compiled()
+            # First invocation triggers lazy Dynamo tracing; apply the
+            # isolated config so _DEFAULT_DYNAMO_CONFIG overrides take effect.
+            with _isolated_dynamo_config():
+                return state.compiled_entry(*args, **kwargs)
+        return state.compiled_entry(*args, **kwargs)
+
+    # --- MAGI_COMPILE path below ---
+
     # JIT Fast Path
     if state.jit_compiled_code is not None:
         with state.dispatch_to_compiled_fwd(mode="jit") as compiled_runtime_invoker:
@@ -105,9 +122,6 @@ def _run_orchestration(state: MagiCompileState, args, kwargs):
                 return compiled_runtime_invoker(*args, **kwargs)
 
     # First compilation
-    state._ensure_compiled()
-
-    # Mark dynamic and static shapes
     _apply_shape_marks(state, args, kwargs)
 
     magi_logger.info(f"Start compiling function {state.original_code_for_hook}")
@@ -115,17 +129,19 @@ def _run_orchestration(state: MagiCompileState, args, kwargs):
     CompileMonitor().start()
 
     try:
-        if state.compile_config.aot:
-            with _compilation_context(state):
+        with _compilation_context(state):
+            state._ensure_compiled()
+
+            if state.compile_config.aot:
                 state.aot_compile(*args, **kwargs)
+            else:
+                with state._jit_capture_compiled_bytecode():
+                    return state.compiled_entry(*args, **kwargs)
+
+        if state.compile_config.aot:
             state.save_aot_compile_artifacts()
             with state.dispatch_to_compiled_fwd(mode="aot") as compiled_runtime_invoker:
                 return compiled_runtime_invoker(*args, **kwargs)
-        else:
-            with _compilation_context(state):
-                # For JIT, we need to capture bytecode.
-                with state._jit_capture_compiled_bytecode():
-                    return state.compiled_entry(*args, **kwargs)
     finally:
         CompileMonitor().end()
         state.traced_files.clear()
@@ -141,15 +157,20 @@ def _lazy_init_magi_state(
     target_method_name: str | None = None,
     state_attr: str | None = None,
 ):
-    """Lazily initialize MagiCompileState and attach it on ``state_attr``."""
+    """Lazily initialize MagiCompileState and attach it on ``state_attr``.
+
+    Always creates a MagiCompileState (never returns early with None).
+    When ``enable_if`` evaluates to False the compile_mode is downgraded
+    to NONE so that ``_run_orchestration`` can short-circuit cleanly.
+    """
     state_attr = state_attr or get_attr_name_for_state("function")
     if getattr(state_holder, state_attr, None) is not None:
         return
 
     conf = config_patch(copy.deepcopy(get_compile_config()))
     enable = enable_if is None or enable_if()
-    if conf.compile_mode == CompileMode.NONE or not enable:
-        return
+    if not enable:
+        conf.compile_mode = CompileMode.NONE
 
     compilation_counter.num_models_seen += 1
 
@@ -232,18 +253,16 @@ def _magi_compile_bound_method(
             _lazy_init_magi_state(
                 instance, instance, dynamic_arg_dims, enable_if, config_patch, model_tag, method_name, state_attr
             )
-            state = getattr(instance, state_attr, None)
+            state = getattr(instance, state_attr)
 
-        # Keep first trace on CPU when model_cpu_offload is enabled.
-        if state is not None and state.compile_config.offload_config.model_cpu_offload and state.jit_compiled_code is None:
+        if state.compile_config.offload_config.model_cpu_offload and state.jit_compiled_code is None:
             args = offload(args)
             kwargs = offload(kwargs)
 
-        if state is None or torch.compiler.is_compiling():
+        if torch.compiler.is_compiling():
             return old_method(*args, **kwargs)
 
-        with _isolated_dynamo_config():
-            return _run_orchestration(state, args, kwargs)
+        return _run_orchestration(state, args, kwargs)
 
     setattr(instance, method_name, new_call)
     setattr(instance, get_attr_name_for_wrapper_installed_flag(), True)
@@ -274,13 +293,12 @@ def _magi_compile_function(
         state = getattr(wrapper, state_attr, None)
         if state is None:
             _lazy_init_magi_state(wrapper, func, dynamic_arg_dims, enable_if, config_patch, model_tag, None, state_attr)
-            state = getattr(wrapper, state_attr, None)
+            state = getattr(wrapper, state_attr)
 
-        if state is None or torch.compiler.is_compiling():
+        if torch.compiler.is_compiling():
             return func(*args, **kwargs)
 
-        with _isolated_dynamo_config():
-            return _run_orchestration(state, args, kwargs)
+        return _run_orchestration(state, args, kwargs)
 
     return wrapper
 
@@ -394,15 +412,23 @@ def _mark_static_shapes(bound, dynamic_records, owner=None):
 
 @contextmanager
 def _compilation_context(state: MagiCompileState):
-    """Active only during Dynamo tracing + inductor compilation.
+    """Active only during first-time Dynamo tracing + inductor compilation.
 
-    Dynamo config:
+    Isolates all dynamo config changes so they do not leak to the caller.
+
+    Dynamo config patches:
     - assume_static_by_default=False: Python int attrs (e.g. group_size_cpu)
       become SymInt graph inputs instead of specialized constants.
     - enable_cpp_symbolic_shape_guards=False: C++ guards do not support
       the symbolic shape patterns produced by our dynamic setup.
     - force_nn_module_property_static_shapes=False: allow nn.Module tensor
       properties (e.g. registered buffers) to keep dynamic shapes.
+    - enable_aot_compile=True: so that torch.compile produces an
+      .aot_compile entry-point (harmless for JIT path).
+
+    All dynamo config is restored on exit via ``_isolated_dynamo_config``
+    (a full snapshot-restore), which also catches any implicit config
+    mutations made by Dynamo internals during compilation.
 
     Tracing hooks:
     - _hijack_inline_call: collect traced Python source files for
@@ -419,9 +445,11 @@ def _compilation_context(state: MagiCompileState):
     _cache_dump_path = cache_dump_path(state.compile_config.cache_root_dir, state.model_idx, state.model_tag)
 
     with (
+        _isolated_dynamo_config(),
         patch.object(torch._dynamo.config, "assume_static_by_default", False),
         patch.object(torch._dynamo.config, "enable_cpp_symbolic_shape_guards", False),
         patch.object(torch._dynamo.config, "force_nn_module_property_static_shapes", False),
+        patch.object(torch._dynamo.config, "enable_aot_compile", True),
         _hijack_inline_call_to_collect_traced_files(state),
         patch.dict(os.environ, {"TORCHINDUCTOR_CACHE_DIR": (_cache_dump_path / "inductor_cache").as_posix()}),
         explain_compilation(_debug_dump_path.as_posix()),

--- a/magi_compiler/_api.py
+++ b/magi_compiler/_api.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import functools
 import gc
 import inspect
@@ -32,7 +31,7 @@ from magi_compiler.magi_backend.magi_compiler_base import MagiCompileState
 from magi_compiler.utils import compilation_counter, envs, magi_logger
 from magi_compiler.utils.compile_time_monitor import CompileMonitor
 
-from .config import CompileConfig, CompileMode, get_compile_config
+from .config import CompileConfig, CompileMode
 
 
 # =============================================================================
@@ -86,7 +85,7 @@ def _run_orchestration(state: MagiCompileState, args, kwargs):
     Central orchestration logic for magi_compile.
 
     Dispatch order:
-    0. NONE / TORCH_COMPILE — short-circuit before any magi logic.
+    0. TORCH_COMPILE — short-circuit before MAGI-specific logic.
     1. JIT Fast Path: If bytecode is already captured, swap and run.
     2. AOT Fast Path: If AOT artifacts exist, load, swap, and run.
     3. First-time Compilation (MAGI_COMPILE only):
@@ -95,9 +94,6 @@ def _run_orchestration(state: MagiCompileState, args, kwargs):
        - (Optional) Perform AOT compilation and save artifacts.
     """
     compile_mode = state.compile_config.compile_mode
-
-    if compile_mode == CompileMode.NONE:
-        return state.original_entry(*args, **kwargs)
 
     if compile_mode == CompileMode.TORCH_COMPILE:
         if state.compiled_entry is None:
@@ -151,32 +147,16 @@ def _lazy_init_magi_state(
     state_holder: object,
     compile_obj: object,
     dynamic_arg_dims: dict[str, int | list[int]] | None,
-    enable_if: Callable[[], bool] | None,
-    config_patch: Callable[[CompileConfig], CompileConfig],
-    model_tag: str | None,
-    target_method_name: str | None = None,
-    state_attr: str | None = None,
+    conf: CompileConfig,
+    model_tag: str,
+    target_method_name: str | None,
+    state_attr: str,
 ):
-    """Lazily initialize MagiCompileState and attach it on ``state_attr``.
-
-    Always creates a MagiCompileState (never returns early with None).
-    When ``enable_if`` evaluates to False the compile_mode is downgraded
-    to NONE so that ``_run_orchestration`` can short-circuit cleanly.
-    """
-    state_attr = state_attr or get_attr_name_for_state("function")
+    """Lazily initialize MagiCompileState and attach it on ``state_attr``."""
     if getattr(state_holder, state_attr, None) is not None:
         return
 
-    conf = config_patch(copy.deepcopy(get_compile_config()))
-    enable = enable_if is None or enable_if()
-    if not enable:
-        conf.compile_mode = CompileMode.NONE
-
     compilation_counter.num_models_seen += 1
-
-    # Infer default model tag if not provided
-    if model_tag is None:
-        model_tag = getattr(compile_obj, "__name__", compile_obj.__class__.__name__)
 
     setattr(
         state_holder,
@@ -193,14 +173,9 @@ def _lazy_init_magi_state(
 
 
 def _magi_compile_class(
-    cls: type,
-    dynamic_arg_dims: dict[str, int | list[int]],
-    enable_if: Callable[[], bool] | None,
-    config_patch: Callable[[CompileConfig], CompileConfig],
-    model_tag: str | None,
-    method_name: str,
+    cls: type, dynamic_arg_dims: dict[str, int | list[int]], conf: CompileConfig, model_tag: str, method_name: str
 ):
-    """Install class-level lazy compilation for ``method_name``.
+    """Install class-level compilation for ``method_name``.
 
     This wraps ``cls.__init__`` so every new instance is patched by
     ``_magi_compile_bound_method`` after initialization.
@@ -212,7 +187,7 @@ def _magi_compile_class(
     if not callable(getattr(cls, method_name, None)):
         raise AttributeError(f"{cls.__name__} has no callable method '{method_name}'")
 
-    if issubclass(cls, nn.Module) and config_patch(copy.deepcopy(get_compile_config())).offload_config.model_cpu_offload:
+    if issubclass(cls, nn.Module) and conf.offload_config.model_cpu_offload:
         _patch_cpu_offload_apply(cls)
 
     old_init = cls.__init__
@@ -220,7 +195,7 @@ def _magi_compile_class(
     @functools.wraps(old_init)
     def wrapped_init(self, *args, **kwargs):
         old_init(self, *args, **kwargs)
-        _magi_compile_bound_method(self, dynamic_arg_dims, enable_if, config_patch, model_tag, method_name=method_name)
+        _magi_compile_bound_method(self, dynamic_arg_dims, conf, model_tag, method_name=method_name)
 
     cls.__init__ = wrapped_init
     setattr(cls, compile_flag_attr, True)
@@ -228,14 +203,9 @@ def _magi_compile_class(
 
 
 def _magi_compile_bound_method(
-    instance: object,
-    dynamic_arg_dims: dict[str, int | list[int]],
-    enable_if: Callable[[], bool] | None,
-    config_patch: Callable[[CompileConfig], CompileConfig],
-    model_tag: str | None,
-    method_name: str,
+    instance: object, dynamic_arg_dims: dict[str, int | list[int]], conf: CompileConfig, model_tag: str, method_name: str
 ):
-    """Patch one instance method with lazy state initialization and compiled routing."""
+    """Patch one instance method with compiled routing."""
     if not callable(getattr(instance, method_name, None)):
         raise AttributeError(f"{instance.__class__.__name__} instance has no callable method '{method_name}'")
 
@@ -248,11 +218,8 @@ def _magi_compile_bound_method(
     @torch.compiler.disable()
     def new_call(*args, **kwargs):
         state = getattr(instance, state_attr, None)
-
         if state is None:
-            _lazy_init_magi_state(
-                instance, instance, dynamic_arg_dims, enable_if, config_patch, model_tag, method_name, state_attr
-            )
+            _lazy_init_magi_state(instance, instance, dynamic_arg_dims, conf, model_tag, method_name, state_attr)
             state = getattr(instance, state_attr)
 
         if state.compile_config.offload_config.model_cpu_offload and state.jit_compiled_code is None:
@@ -269,30 +236,18 @@ def _magi_compile_bound_method(
     return instance
 
 
-def _magi_compile_function(
-    func: Callable,
-    dynamic_arg_dims: dict[str, int | list[int]],
-    enable_if: Callable[[], bool] | None,
-    config_patch: Callable[[CompileConfig], CompileConfig] | None,
-    model_tag: str | None,
-):
-    """Wrap a function entry with lazy ``MagiCompileState`` and compiled routing.
-
-    The returned wrapper initializes state on first invocation and then dispatches
-    through ``_run_orchestration``.
-    """
+def _magi_compile_function(func: Callable, dynamic_arg_dims: dict[str, int | list[int]], conf: CompileConfig, model_tag: str):
+    """Wrap a function entry with compiled routing."""
     state_attr = get_attr_name_for_state("function")
     if getattr(func, state_attr, None) is not None:
         return func
-
-    config_patch = config_patch or (lambda x: x)
 
     @torch.compiler.disable()
     @functools.wraps(func)  # for the original function name and docstring
     def wrapper(*args, **kwargs):
         state = getattr(wrapper, state_attr, None)
         if state is None:
-            _lazy_init_magi_state(wrapper, func, dynamic_arg_dims, enable_if, config_patch, model_tag, None, state_attr)
+            _lazy_init_magi_state(wrapper, func, dynamic_arg_dims, conf, model_tag, None, state_attr)
             state = getattr(wrapper, state_attr)
 
         if torch.compiler.is_compiling():

--- a/magi_compiler/api.py
+++ b/magi_compiler/api.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import functools
 import inspect
 from typing import Callable, TypeVar
@@ -22,9 +23,10 @@ from ._api import (
     _magi_compile_bound_method,
     _magi_compile_class,
     _magi_compile_function,
+    get_compile_config,
 )
 from ._magi_register_custom_op import _magi_register_custom_op_impl
-from .config import CompileConfig
+from .config import CompileConfig, CompileMode
 
 _T = TypeVar("_T", bound=type)
 _F = TypeVar("_F", bound=Callable)
@@ -127,6 +129,13 @@ def magi_compile(
         )
 
     config_patch = config_patch or (lambda x: x)
+    conf = config_patch(copy.deepcopy(get_compile_config()))
+    enable = enable_if is None or enable_if()
+    if not enable:
+        conf.compile_mode = CompileMode.NONE
+
+    if conf.compile_mode == CompileMode.NONE:
+        return obj
 
     is_bound_method = inspect.ismethod(obj)
     is_function = inspect.isfunction(obj)
@@ -171,17 +180,20 @@ def magi_compile(
 
     _check_dynamic_arg_dims(inferred_dims, target_func)
 
+    if model_tag is None:
+        model_tag = getattr(obj, "__name__", obj.__class__.__name__)
+
     # 3. Dispatch by entry kind (class / instance / bound method / bare function)
 
     if is_class:
-        return _magi_compile_class(obj, inferred_dims, enable_if, config_patch, model_tag, method_name)
+        return _magi_compile_class(obj, inferred_dims, conf, model_tag, method_name)
     elif is_instance:
-        return _magi_compile_bound_method(obj, inferred_dims, enable_if, config_patch, model_tag, method_name)
+        return _magi_compile_bound_method(obj, inferred_dims, conf, model_tag, method_name)
     elif is_bound_method:
-        _magi_compile_bound_method(owner_instance, inferred_dims, enable_if, config_patch, model_tag, method_name)
+        _magi_compile_bound_method(owner_instance, inferred_dims, conf, model_tag, method_name)
         return getattr(owner_instance, method_name)
     elif is_function:
-        return _magi_compile_function(obj, inferred_dims, enable_if, config_patch, model_tag)
+        return _magi_compile_function(obj, inferred_dims, conf, model_tag)
 
     raise TypeError(f"Unsupported type for magi_compile: {type(obj)}")
 

--- a/magi_compiler/api.py
+++ b/magi_compiler/api.py
@@ -23,10 +23,9 @@ from ._api import (
     _magi_compile_bound_method,
     _magi_compile_class,
     _magi_compile_function,
-    get_compile_config,
 )
 from ._magi_register_custom_op import _magi_register_custom_op_impl
-from .config import CompileConfig, CompileMode
+from .config import CompileConfig, CompileMode, get_compile_config
 
 _T = TypeVar("_T", bound=type)
 _F = TypeVar("_F", bound=Callable)
@@ -131,10 +130,7 @@ def magi_compile(
     config_patch = config_patch or (lambda x: x)
     conf = config_patch(copy.deepcopy(get_compile_config()))
     enable = enable_if is None or enable_if()
-    if not enable:
-        conf.compile_mode = CompileMode.NONE
-
-    if conf.compile_mode == CompileMode.NONE:
+    if not enable or conf.compile_mode == CompileMode.NONE:
         return obj
 
     is_bound_method = inspect.ismethod(obj)

--- a/magi_compiler/magi_backend/magi_compiler_base.py
+++ b/magi_compiler/magi_backend/magi_compiler_base.py
@@ -140,8 +140,6 @@ class MagiCompileState:
             options = options or {}
             # Drop all the guards in the AOT compile mode as bytecode hook is not used anymore.
             options["guard_filter_fn"] = lambda guards: [False for _ in guards]
-            assert hasattr(torch._dynamo.config, "enable_aot_compile"), "enable_aot_compile config not available"
-            torch._dynamo.config.enable_aot_compile = True
 
         # torch.compile returns a ``compile_wrapper`` closure defined in
         # torch/_dynamo/eval_frame.py.  When ``enable_aot_compile=True`` it

--- a/tests/api_tests/test_register_custom_op.py
+++ b/tests/api_tests/test_register_custom_op.py
@@ -474,7 +474,7 @@ def magi_compile_config():
     """Fixture to set up a clean compile configuration for magi_compile tests."""
     compile_config = CompileConfig(compile_mode=CompileMode.TORCH_COMPILE, cache_root_dir=tempfile.mkdtemp())
 
-    with patch("magi_compiler._api.get_compile_config") as mock_get_config, patch("torch.distributed.get_rank") as mock_rank:
+    with patch("magi_compiler.api.get_compile_config") as mock_get_config, patch("torch.distributed.get_rank") as mock_rank:
         mock_get_config.return_value = compile_config
         mock_rank.return_value = 0
         yield compile_config

--- a/tests/feature_tests/cache_reuse_helper/autograd_cache_flag_helper.py
+++ b/tests/feature_tests/cache_reuse_helper/autograd_cache_flag_helper.py
@@ -49,7 +49,6 @@ import torch._inductor as _inductor_mod
 import torch.nn as nn
 
 from magi_compiler import magi_compile
-from magi_compiler.config import CompileMode, get_compile_config
 from magi_compiler.utils import compilation_counter
 
 DEVICE = "cuda"
@@ -89,14 +88,8 @@ class TrainingModel(nn.Module):
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--cache-root", required=True)
     parser.add_argument("--output", required=True)
     args = parser.parse_args()
-
-    config = get_compile_config()
-    config.compile_mode = CompileMode.MAGI_COMPILE
-    config.aot = False
-    config.cache_root_dir = args.cache_root
 
     torch._dynamo.reset()
     torch.manual_seed(2026)

--- a/tests/feature_tests/cache_reuse_helper/restart_analysis_cache_helper.py
+++ b/tests/feature_tests/cache_reuse_helper/restart_analysis_cache_helper.py
@@ -13,7 +13,7 @@ import torch
 import torch.nn as nn
 
 from magi_compiler import magi_compile, magi_register_custom_op
-from magi_compiler.config import CompileMode, get_compile_config
+from magi_compiler.config import get_compile_config
 
 DEVICE = "cuda"
 DTYPE = torch.bfloat16
@@ -107,17 +107,12 @@ def _collect_new_run_dirs(cache_root: Path, before: set[str]) -> list[Path]:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--cache-root", required=True)
     parser.add_argument("--output", required=True)
     args = parser.parse_args()
 
-    cache_root = Path(args.cache_root)
-    run_dirs_before = {str(p) for p in cache_root.rglob("run_*") if p.is_dir()}
-
     config = get_compile_config()
-    config.compile_mode = CompileMode.MAGI_COMPILE
-    config.aot = False
-    config.cache_root_dir = args.cache_root
+    cache_root = Path(config.cache_root_dir)
+    run_dirs_before = {str(p) for p in cache_root.rglob("run_*") if p.is_dir()}
 
     torch._dynamo.reset()
     torch.manual_seed(2026)

--- a/tests/feature_tests/cache_reuse_helper/transformer_cache_reuse_helper.py
+++ b/tests/feature_tests/cache_reuse_helper/transformer_cache_reuse_helper.py
@@ -13,7 +13,7 @@ import torch
 import torch.nn as nn
 
 from magi_compiler import magi_compile, magi_register_custom_op
-from magi_compiler.config import CompileMode, get_compile_config
+from magi_compiler.config import get_compile_config
 
 DEVICE = "cuda"
 DTYPE = torch.float16
@@ -99,16 +99,11 @@ def make_input() -> torch.Tensor:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--cache-root", required=True)
     parser.add_argument("--output", required=True)
-    parser.add_argument("--run-mode", choices=["jit", "aot"], required=True)
     parser.add_argument("--run-kind", choices=["baseline", "cache"], required=True)
     args = parser.parse_args()
 
     config = get_compile_config()
-    config.compile_mode = CompileMode.MAGI_COMPILE
-    config.aot = args.run_mode == "aot"
-    config.cache_root_dir = args.cache_root
     config.splitting_ops = ["test::scaled_dot_product_attn_boundary"]
 
     torch._dynamo.reset()
@@ -122,7 +117,7 @@ def main() -> None:
         y = model(x)
 
     payload = {
-        "mode": args.run_mode,
+        "mode": "aot" if config.aot else "jit",
         "run_kind": args.run_kind,
         "shape": list(y.shape),
         "sum": float(y.float().sum().item()),

--- a/tests/feature_tests/test_autograd_function_cache_flag.py
+++ b/tests/feature_tests/test_autograd_function_cache_flag.py
@@ -57,13 +57,11 @@ def test_autograd_cache_flag_and_cache_reuse(tmp_path: Path):
 
     env = os.environ.copy()
     env["MAGI_LOGGING_LEVEL"] = "info"
+    env["MAGI_COMPILE_CACHE_ROOT_DIR"] = str(cache_root)
 
     def _run(output: Path) -> subprocess.CompletedProcess:
         return subprocess.run(
-            [sys.executable, str(helper_path), "--cache-root", str(cache_root), "--output", str(output)],
-            env=env,
-            capture_output=True,
-            text=True,
+            [sys.executable, str(helper_path), "--output", str(output)], env=env, capture_output=True, text=True
         )
 
     # ── Run 1: warm cache ────────────────────────────────────────────────────

--- a/tests/feature_tests/test_cuda_graph.py
+++ b/tests/feature_tests/test_cuda_graph.py
@@ -78,7 +78,7 @@ class TestCudaGraphFullMode:
 
         compile_config = _create_compile_config(cache_dir, CudaGraphMode.FULL)
 
-        with patch("magi_compiler._api.get_compile_config", return_value=compile_config), patch(
+        with patch("magi_compiler.api.get_compile_config", return_value=compile_config), patch(
             "torch.distributed.get_rank", return_value=0
         ):
 
@@ -149,7 +149,7 @@ class TestCudaGraphPiecewiseMode:
 
         compile_config = _create_compile_config(cache_dir, CudaGraphMode.PIECEWISE)
 
-        with patch("magi_compiler._api.get_compile_config", return_value=compile_config), patch(
+        with patch("magi_compiler.api.get_compile_config", return_value=compile_config), patch(
             "torch.distributed.get_rank", return_value=0
         ):
 
@@ -227,7 +227,7 @@ class TestCudaGraphParameterHandling:
 
         compile_config = _create_compile_config(cache_dir, CudaGraphMode.FULL)
 
-        with patch("magi_compiler._api.get_compile_config", return_value=compile_config), patch(
+        with patch("magi_compiler.api.get_compile_config", return_value=compile_config), patch(
             "torch.distributed.get_rank", return_value=0
         ):
 

--- a/tests/feature_tests/test_restart_analysis_cache.py
+++ b/tests/feature_tests/test_restart_analysis_cache.py
@@ -30,13 +30,14 @@ def test_restart_analysis_cache_handle_marks_and_skips_artifact_load(tmp_path: P
 
     env = os.environ.copy()
     env["MAGI_LOGGING_LEVEL"] = "info"
+    env["MAGI_COMPILE_CACHE_ROOT_DIR"] = str(cache_root)
 
-    cmd1 = [sys.executable, str(helper_path), "--cache-root", str(cache_root), "--output", str(out1)]
+    cmd1 = [sys.executable, str(helper_path), "--output", str(out1)]
     p1 = subprocess.run(cmd1, env=env, capture_output=True, text=True)
     assert p1.returncode == 0, f"worker1 failed\nstdout:\n{p1.stdout}\nstderr:\n{p1.stderr}"
     assert "standalone_compile raised RestartAnalysis" in p1.stderr
 
-    cmd2 = [sys.executable, str(helper_path), "--cache-root", str(cache_root), "--output", str(out2)]
+    cmd2 = [sys.executable, str(helper_path), "--output", str(out2)]
     p2 = subprocess.run(cmd2, env=env, capture_output=True, text=True)
     assert p2.returncode == 0, f"worker2 failed\nstdout:\n{p2.stdout}\nstderr:\n{p2.stderr}"
     assert "too many values to unpack" not in p2.stderr

--- a/tests/feature_tests/test_transformer_cache_reuse.py
+++ b/tests/feature_tests/test_transformer_cache_reuse.py
@@ -27,61 +27,31 @@ def test_transformer_cache_reuse_across_processes(tmp_path: Path, run_mode: str)
 
     env = os.environ.copy()
     env["MAGI_LOGGING_LEVEL"] = "info"
+    env["MAGI_COMPILE_AOT"] = "true" if run_mode == "aot" else "false"
 
+    baseline_env = {**env, "MAGI_COMPILE_CACHE_ROOT_DIR": str(tmp_path / f"baseline_cache_{run_mode}")}
     baseline = subprocess.run(
-        [
-            sys.executable,
-            str(helper_path),
-            "--cache-root",
-            str(tmp_path / f"baseline_cache_{run_mode}"),
-            "--output",
-            str(baseline_out),
-            "--run-mode",
-            run_mode,
-            "--run-kind",
-            "baseline",
-        ],
+        [sys.executable, str(helper_path), "--output", str(baseline_out), "--run-kind", "baseline"],
         capture_output=True,
         text=True,
-        env=env,
+        env=baseline_env,
     )
     assert baseline.returncode == 0, f"baseline process failed (mode={run_mode})\n{baseline.stderr}"
 
+    cache_env = {**env, "MAGI_COMPILE_CACHE_ROOT_DIR": str(cache_root)}
     run1 = subprocess.run(
-        [
-            sys.executable,
-            str(helper_path),
-            "--cache-root",
-            str(cache_root),
-            "--output",
-            str(cache_out1),
-            "--run-mode",
-            run_mode,
-            "--run-kind",
-            "cache",
-        ],
+        [sys.executable, str(helper_path), "--output", str(cache_out1), "--run-kind", "cache"],
         capture_output=True,
         text=True,
-        env=env,
+        env=cache_env,
     )
     assert run1.returncode == 0, f"cache run1 failed (mode={run_mode})\n{run1.stderr}"
 
     run2 = subprocess.run(
-        [
-            sys.executable,
-            str(helper_path),
-            "--cache-root",
-            str(cache_root),
-            "--output",
-            str(cache_out2),
-            "--run-mode",
-            run_mode,
-            "--run-kind",
-            "cache",
-        ],
+        [sys.executable, str(helper_path), "--output", str(cache_out2), "--run-kind", "cache"],
         capture_output=True,
         text=True,
-        env=env,
+        env=cache_env,
     )
     assert run2.returncode == 0, f"cache run2 failed (mode={run_mode})\n{run2.stderr}"
 

--- a/tests/model_definition.py
+++ b/tests/model_definition.py
@@ -244,10 +244,10 @@ class RawNonModulePointwiseFusionChain:
 class RawNonModuleNormResidualActivation:
     """Non-module norm+residual+activation workload aligned with module math."""
 
-    def __init__(self, hidden_size: int, eps: float = 1e-6):
+    def __init__(self, hidden_size: int, eps: float = 1e-6, device: torch.device | str = "cuda"):
         self.hidden_size = hidden_size
         self.eps = eps
-        self.weight = torch.ones(hidden_size, dtype=torch.float32)
+        self.weight = torch.ones(hidden_size, dtype=torch.float32, device=device)
 
     def copy_from(self, other: Self) -> None:
         self.weight = other.weight.clone()

--- a/tests/perf_tests/test_norm_residual_fusion_perf.py
+++ b/tests/perf_tests/test_norm_residual_fusion_perf.py
@@ -33,7 +33,7 @@ from magi_compiler import magi_compile
 from magi_compiler.config import CompileMode
 from tests.model_definition import RawNonModuleNormResidualActivation, RMSNorm
 from tests.perf_tests import cuda_benchmark, print_perf_comparison
-from tests.perf_tests.utils import assert_speedup
+from tests.perf_tests.utils import assert_magi_vs_torch, assert_speedup
 
 HIDDEN_SIZE = 4096
 NUM_TOKENS = 16384
@@ -69,7 +69,9 @@ def nra_baselines(nra_device, nra_inputs):
     """Eager and torch.compile baselines, benchmarked once for the whole module."""
     x, residual = nra_inputs
     eager_model = NormResidualActivation(HIDDEN_SIZE).to(nra_device).eval()
-    torch_compiled = torch.compile(NormResidualActivation(HIDDEN_SIZE).to(nra_device).eval(), backend="inductor")
+    torch_compiled = torch.compile(
+        NormResidualActivation(HIDDEN_SIZE).to(nra_device).eval(), fullgraph=True, dynamic=True, backend="inductor"
+    )
     with torch.no_grad():
         eager_result = cuda_benchmark(lambda: eager_model(x, residual))
         torch_result = cuda_benchmark(lambda: torch_compiled(x, residual), compilation_warmup=3)
@@ -94,7 +96,7 @@ def test_norm_residual_class_decoration(nra_device, nra_inputs, nra_baselines):
     with torch.no_grad():
         magi_result = cuda_benchmark(lambda: magi_compiled(x, residual), compilation_warmup=3)
 
-    magi_vs_eager, _ = print_perf_comparison(
+    magi_vs_eager, magi_vs_torch = print_perf_comparison(
         "Norm+Residual+SiLU - class decoration",
         eager_result,
         magi_result,
@@ -102,6 +104,7 @@ def test_norm_residual_class_decoration(nra_device, nra_inputs, nra_baselines):
         extra_info=f"shape=({NUM_TOKENS}, {HIDDEN_SIZE})  dtype=bf16",
     )
     assert_speedup(magi_vs_eager, eager_result, magi_result, "class", SPEEDUP_VS_EAGER_THRESHOLD)
+    assert_magi_vs_torch(magi_vs_torch, torch_result, magi_result, "class")
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA support")
@@ -116,7 +119,7 @@ def test_norm_residual_instance_decoration(nra_device, nra_inputs, nra_baselines
     with torch.no_grad():
         magi_result = cuda_benchmark(lambda: magi_compiled(x, residual), compilation_warmup=3)
 
-    magi_vs_eager, _ = print_perf_comparison(
+    magi_vs_eager, magi_vs_torch = print_perf_comparison(
         "Norm+Residual+SiLU - instance decoration",
         eager_result,
         magi_result,
@@ -124,6 +127,7 @@ def test_norm_residual_instance_decoration(nra_device, nra_inputs, nra_baselines
         extra_info=f"shape=({NUM_TOKENS}, {HIDDEN_SIZE})  dtype=bf16",
     )
     assert_speedup(magi_vs_eager, eager_result, magi_result, "instance", SPEEDUP_VS_EAGER_THRESHOLD)
+    assert_magi_vs_torch(magi_vs_torch, torch_result, magi_result, "instance")
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA support")
@@ -144,7 +148,7 @@ def test_norm_residual_instance_torch_compile_mode(nra_device, nra_inputs, nra_b
     with torch.no_grad():
         magi_result = cuda_benchmark(lambda: magi_compiled(x, residual), compilation_warmup=3)
 
-    magi_vs_eager, _ = print_perf_comparison(
+    magi_vs_eager, magi_vs_torch = print_perf_comparison(
         "Norm+Residual+SiLU - instance (TORCH_COMPILE mode)",
         eager_result,
         magi_result,
@@ -152,6 +156,7 @@ def test_norm_residual_instance_torch_compile_mode(nra_device, nra_inputs, nra_b
         extra_info=f"shape=({NUM_TOKENS}, {HIDDEN_SIZE})  dtype=bf16",
     )
     assert_speedup(magi_vs_eager, eager_result, magi_result, "instance_tc", SPEEDUP_VS_EAGER_THRESHOLD)
+    assert_magi_vs_torch(magi_vs_torch, torch_result, magi_result, "instance_tc")
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA support")
@@ -169,7 +174,7 @@ def test_norm_residual_function_decoration(nra_device, nra_inputs, nra_baselines
     with torch.no_grad():
         magi_result = cuda_benchmark(lambda: compiled_entry(x, residual), compilation_warmup=3)
 
-    magi_vs_eager, _ = print_perf_comparison(
+    magi_vs_eager, magi_vs_torch = print_perf_comparison(
         "Norm+Residual+SiLU - function decoration",
         eager_result,
         magi_result,
@@ -177,6 +182,7 @@ def test_norm_residual_function_decoration(nra_device, nra_inputs, nra_baselines
         extra_info=f"shape=({NUM_TOKENS}, {HIDDEN_SIZE})  dtype=bf16",
     )
     assert_speedup(magi_vs_eager, eager_result, magi_result, "function", SPEEDUP_VS_EAGER_THRESHOLD)
+    assert_magi_vs_torch(magi_vs_torch, torch_result, magi_result, "function")
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA support")
@@ -191,7 +197,7 @@ def test_norm_residual_method_decoration(nra_device, nra_inputs, nra_baselines):
     with torch.no_grad():
         magi_result = cuda_benchmark(lambda: magi_compiled(x, residual), compilation_warmup=3)
 
-    magi_vs_eager, _ = print_perf_comparison(
+    magi_vs_eager, magi_vs_torch = print_perf_comparison(
         "Norm+Residual+SiLU - method decoration",
         eager_result,
         magi_result,
@@ -199,6 +205,7 @@ def test_norm_residual_method_decoration(nra_device, nra_inputs, nra_baselines):
         extra_info=f"shape=({NUM_TOKENS}, {HIDDEN_SIZE})  dtype=bf16",
     )
     assert_speedup(magi_vs_eager, eager_result, magi_result, "method", SPEEDUP_VS_EAGER_THRESHOLD)
+    assert_magi_vs_torch(magi_vs_torch, torch_result, magi_result, "method")
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA support")

--- a/tests/perf_tests/test_pointwise_fusion_perf.py
+++ b/tests/perf_tests/test_pointwise_fusion_perf.py
@@ -32,7 +32,7 @@ from magi_compiler import magi_compile
 from magi_compiler.config import CompileMode
 from tests.model_definition import RawNonModulePointwiseFusionChain
 from tests.perf_tests import cuda_benchmark, print_perf_comparison
-from tests.perf_tests.utils import assert_speedup
+from tests.perf_tests.utils import assert_magi_vs_torch, assert_speedup
 
 HIDDEN_SIZE = 4096
 NUM_TOKENS = 16384
@@ -68,7 +68,9 @@ def pointwise_baselines(pointwise_device, pointwise_input):
     """Eager and torch.compile baselines, benchmarked once for the whole module."""
     x = pointwise_input
     eager_model = PointwiseFusionChain().to(pointwise_device).eval()
-    torch_compiled = torch.compile(PointwiseFusionChain().to(pointwise_device).eval(), backend="inductor")
+    torch_compiled = torch.compile(
+        PointwiseFusionChain().to(pointwise_device).eval(), fullgraph=True, dynamic=True, backend="inductor"
+    )
     with torch.no_grad():
         eager_result = cuda_benchmark(lambda: eager_model(x))
         torch_result = cuda_benchmark(lambda: torch_compiled(x), compilation_warmup=3)
@@ -92,7 +94,7 @@ def test_pointwise_class_decoration(pointwise_device, pointwise_input, pointwise
     with torch.no_grad():
         magi_result = cuda_benchmark(lambda: magi_compiled(pointwise_input), compilation_warmup=3)
 
-    magi_vs_eager, _ = print_perf_comparison(
+    magi_vs_eager, magi_vs_torch = print_perf_comparison(
         "Pointwise - class decoration",
         eager_result,
         magi_result,
@@ -100,6 +102,7 @@ def test_pointwise_class_decoration(pointwise_device, pointwise_input, pointwise
         extra_info=f"shape=({NUM_TOKENS}, {HIDDEN_SIZE})",
     )
     assert_speedup(magi_vs_eager, eager_result, magi_result, "class", SPEEDUP_VS_EAGER_THRESHOLD)
+    assert_magi_vs_torch(magi_vs_torch, torch_result, magi_result, "class")
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA support")
@@ -113,7 +116,7 @@ def test_pointwise_instance_decoration(pointwise_device, pointwise_input, pointw
     with torch.no_grad():
         magi_result = cuda_benchmark(lambda: magi_compiled(pointwise_input), compilation_warmup=3)
 
-    magi_vs_eager, _ = print_perf_comparison(
+    magi_vs_eager, magi_vs_torch = print_perf_comparison(
         "Pointwise - instance decoration",
         eager_result,
         magi_result,
@@ -121,6 +124,7 @@ def test_pointwise_instance_decoration(pointwise_device, pointwise_input, pointw
         extra_info=f"shape=({NUM_TOKENS}, {HIDDEN_SIZE})",
     )
     assert_speedup(magi_vs_eager, eager_result, magi_result, "instance", SPEEDUP_VS_EAGER_THRESHOLD)
+    assert_magi_vs_torch(magi_vs_torch, torch_result, magi_result, "instance")
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA support")
@@ -138,7 +142,7 @@ def test_pointwise_instance_torch_compile_mode(pointwise_device, pointwise_input
     with torch.no_grad():
         magi_result = cuda_benchmark(lambda: magi_compiled(pointwise_input), compilation_warmup=3)
 
-    magi_vs_eager, _ = print_perf_comparison(
+    magi_vs_eager, magi_vs_torch = print_perf_comparison(
         "Pointwise - instance (TORCH_COMPILE mode)",
         eager_result,
         magi_result,
@@ -146,6 +150,7 @@ def test_pointwise_instance_torch_compile_mode(pointwise_device, pointwise_input
         extra_info=f"shape=({NUM_TOKENS}, {HIDDEN_SIZE})",
     )
     assert_speedup(magi_vs_eager, eager_result, magi_result, "instance_tc", SPEEDUP_VS_EAGER_THRESHOLD)
+    assert_magi_vs_torch(magi_vs_torch, torch_result, magi_result, "instance_tc")
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA support")
@@ -162,7 +167,7 @@ def test_pointwise_function_decoration(pointwise_device, pointwise_input, pointw
     with torch.no_grad():
         magi_result = cuda_benchmark(lambda: compiled_entry(pointwise_input), compilation_warmup=3)
 
-    magi_vs_eager, _ = print_perf_comparison(
+    magi_vs_eager, magi_vs_torch = print_perf_comparison(
         "Pointwise - function decoration",
         eager_result,
         magi_result,
@@ -170,6 +175,7 @@ def test_pointwise_function_decoration(pointwise_device, pointwise_input, pointw
         extra_info=f"shape=({NUM_TOKENS}, {HIDDEN_SIZE})",
     )
     assert_speedup(magi_vs_eager, eager_result, magi_result, "function", SPEEDUP_VS_EAGER_THRESHOLD)
+    assert_magi_vs_torch(magi_vs_torch, torch_result, magi_result, "function")
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA support")
@@ -183,7 +189,7 @@ def test_pointwise_method_decoration(pointwise_device, pointwise_input, pointwis
     with torch.no_grad():
         magi_result = cuda_benchmark(lambda: magi_compiled(pointwise_input), compilation_warmup=3)
 
-    magi_vs_eager, _ = print_perf_comparison(
+    magi_vs_eager, magi_vs_torch = print_perf_comparison(
         "Pointwise - method decoration",
         eager_result,
         magi_result,
@@ -191,6 +197,7 @@ def test_pointwise_method_decoration(pointwise_device, pointwise_input, pointwis
         extra_info=f"shape=({NUM_TOKENS}, {HIDDEN_SIZE})",
     )
     assert_speedup(magi_vs_eager, eager_result, magi_result, "method", SPEEDUP_VS_EAGER_THRESHOLD)
+    assert_magi_vs_torch(magi_vs_torch, torch_result, magi_result, "method")
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA support")

--- a/tests/perf_tests/utils.py
+++ b/tests/perf_tests/utils.py
@@ -14,6 +14,8 @@
 
 from tests.perf_tests import BenchmarkResult
 
+MAGI_VS_TORCH_THRESHOLD = 0.97
+
 
 def assert_speedup(
     magi_vs_eager: float, eager_result: BenchmarkResult, magi_result: BenchmarkResult, label: str, threshold: float
@@ -22,4 +24,18 @@ def assert_speedup(
         f"[{label}] magi_compile must achieve >= {threshold:.2f}x over eager. "
         f"Got {magi_vs_eager:.2f}x "
         f"(eager={eager_result.median:.3f}ms, magi={magi_result.median:.3f}ms)"
+    )
+
+
+def assert_magi_vs_torch(
+    magi_vs_torch: float,
+    torch_result: BenchmarkResult,
+    magi_result: BenchmarkResult,
+    label: str,
+    threshold: float = MAGI_VS_TORCH_THRESHOLD,
+) -> None:
+    assert magi_vs_torch >= threshold, (
+        f"[{label}] magi_compile must be >= {threshold:.2f}x of torch.compile. "
+        f"Got {magi_vs_torch:.2f}x "
+        f"(torch={torch_result.median:.3f}ms, magi={magi_result.median:.3f}ms)"
     )


### PR DESCRIPTION
## 🗂️ PR Category
<!-- Please check the one that applies to this PR using "[x]". -->

- [ ] ✨ New Feature
- [x] 🚀 Optimization (performance, memory, etc.)
- [ ] 💥 Breaking Change
- [ ] 🐛 Bug Fix
- [x] 🛠️ Development / Refactoring
- [ ] 📚 Documentation
- [ ] 🧹 Chore (Dependencies, CI/CD, Configuration, etc.)
- [x] 🧪 Testing

## 📝 Description
### 1. Move _isolated_dynamo_config off the hot path
Previously every magi_compile forward call went through _isolated_dynamo_config() (full dynamo config snapshot). Now it only runs during first-time compilation inside _compilation_context(), eliminating per-call Python overhead.
### 2. Eagerly resolve CompileConfig at decoration time
api.py now evaluates config_patch + enable_if and produces a frozen conf object upfront, instead of passing callables downstream. CompileMode.NONE short-circuits immediately with zero wrapping.
### 3. Fix config-timing bug in cache-reuse test helpers
The three cache_reuse_helper scripts used @magi_compile class decorators at module top-level but set cache_root_dir in main() — too late. Now cache_root_dir / aot are passed via MAGI_* env vars so the config is correct before module load.

## 📊 Perf Snapshot (current run)
Scenario | torch.compile vs eager | magi vs eager (range) | magi / torch
-- | -- | -- | --
Pointwise fusion | 5.58x | 5.61x ~ 5.92x | 1.01x ~ 1.06x
Norm+Residual+SiLU | 9.43x | 9.42x ~ 9.43x | 1.00x
MLP | 1.82x | 1.79x ~ 1.80x | 0.98x ~ 1.00x