### PR TITLE
[Fix]: handle zero-one specialization in PiecewiseBackend

### DIFF
--- a/magi_compiler/_api.py
+++ b/magi_compiler/_api.py
@@ -314,6 +314,18 @@ def _mark_dynamic_shapes(state: MagiCompileState, bound):
 
         final_dims = [arg.ndim + d if d < 0 else d for d in dims]
 
+        for d in final_dims:
+            dim_size = arg.shape[d]
+            if dim_size <= 1:
+                raise ValueError(
+                    f"Argument '{k}' has size {dim_size} on dynamic dim {d}. "
+                    "PyTorch Dynamo specializes on 0/1 sizes (see "
+                    "https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/compile/"
+                    "dynamic_shapes_zero_one_specialization.html), "
+                    "so this dimension will NOT be treated as dynamic. "
+                    "Use an initial input with size >= 2 on dynamic dims to enable shape generalization."
+                )
+
         torch._dynamo.mark_dynamic(arg, final_dims)
 
         dynamic_records[id(arg)] = set(final_dims)

--- a/magi_compiler/magi_backend/piecewise_backend.py
+++ b/magi_compiler/magi_backend/piecewise_backend.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any
 import torch.fx as fx
 
 from magi_compiler.config import CompileConfig
+from magi_compiler.utils import magi_logger
 
 if TYPE_CHECKING:
     from .magi_backend import CompilerManager
@@ -85,7 +86,9 @@ class PiecewiseBackend:
             self.check_for_ending_compilation()
             return self.compiled_graph_for_general_shape(*args)
 
-        assert len(self.sym_shape_indices) != 0, "No symbolic shape indices found"
+        if len(self.sym_shape_indices) == 0:
+            magi_logger.info("No symbolic shape indices found, falling back to general shape compiled graph")
+            return self.compiled_graph_for_general_shape(*args)
         runtime_shape = args[self.sym_shape_indices[0]]
         if runtime_shape not in self.concrete_size_entries:
             # we don't need to do anything for this shape

--- a/tests/model_tests/test_mlp_infer.py
+++ b/tests/model_tests/test_mlp_infer.py
@@ -46,6 +46,16 @@ def test_mlp_basic_inference(device, mlp_config, mlp_model):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA support")
+def test_mlp_batch1_first_call_raises(device, mlp_config, mlp_model):
+    """First call with batch=1 should raise ValueError due to zero-one specialization"""
+    input_tensor = torch.randn(1, mlp_config.hidden_size, device=device, dtype=torch.bfloat16)
+
+    with torch.no_grad():
+        with pytest.raises(ValueError, match="specializes on 0/1 sizes"):
+            mlp_model(input_tensor)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA support")
 def test_mlp_different_input_shapes(device, mlp_config, mlp_model):
     """Test different input shapes"""
     test_shapes = [


### PR DESCRIPTION
When the first call uses batch size 0 or 1, PyTorch Dynamo specializes that dimension as a static constant, leaving sym_shape_indices empty and causing an AssertionError on subsequent calls with different shapes.

- Raise ValueError early in _mark_dynamic_shapes when dim_size <= 1 so users get a clear, actionable error instead of a cryptic assert
- Replace the hard assert in PiecewiseBackend.__call__ with a fallback to compiled_graph_for_general_shape + info log as a safety net
- Add test_mlp_batch1_first_call_raises regression test

## 🗂️ PR Category
<!-- Please check the one that applies to this PR using "[x]". -->

- [ ] ✨ New Feature
- [ ] 🚀 Optimization (performance, memory, etc.)
- [ ] 💥 Breaking Change
- [x] 🐛 Bug Fix
- [ ] 🛠️ Development / Refactoring
- [ ] 📚 Documentation
- [ ] 🧹 Chore (Dependencies, CI/CD, Configuration, etc.)
- [x] 🧪 Testing

## 📝 Description
<!-- Please provide a clear description of what this PR does. -->

### Problem
From: [ISSUE-23](https://github.com/SandAI-org/MagiCompiler/issues/23)
When the first call to a @magi_compile-decorated module uses batch size 0 or 1, PyTorch Dynamo's [zero-one specialization](https://docs.pytorch.org/docs/stable/user_guide/torch_compiler/compile/dynamic_shapes_zero_one_specialization.html) treats that dimension as a static constant rather than a symbolic value. This causes sym_shape_indices to be empty in PiecewiseBackend, resulting in AssertionError: No symbolic shape indices found on subsequent calls with different shapes.

### Changes

- Raise early with a clear message: Upgrade the existing magi_logger.warning in _mark_dynamic_shapes to a ValueError, so users get an actionable error at the point of compilation rather than a cryptic assert deep in the piecewise backend.

- Add fallback safety net: Replace the hard assert in PiecewiseBackend.__call__ with a graceful fallback to compiled_graph_for_general_shape plus an info log, covering any other scenario where sym_shape_indices might be empty.

- Add regression test: test_mlp_batch1_first_call_raises verifies that calling with batch=1 as the first invocation raises ValueError with a clear message.

### Test

All 5 tests in tests/model_tests/test_mlp_infer.py pass, including the new regression test.

<!-- ## 🔗 Related Issues (Optional) -->
