### PR TITLE
[Fix]: use default MAGI_COMPILE mode in tests and add CI CUDA check

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -31,6 +31,17 @@ jobs:
             run:
                 shell: bash
         steps:
+        -   name: Check environment (torch & CUDA)
+            run: |
+                python3 -c "
+                import torch
+                print(f'PyTorch version: {torch.__version__}')
+                assert torch.cuda.is_available(), 'CUDA is not available on this runner'
+                print(f'CUDA version: {torch.version.cuda}')
+                print(f'GPU: {torch.cuda.get_device_name(0)}')
+                print(f'GPU count: {torch.cuda.device_count()}')
+                "
+
         -   name: Configure git proxy
             run: |
                 git config --global http.proxy "${{ secrets.HTTP_PROXY }}"

--- a/tests/api_tests/test_magi_compile.py
+++ b/tests/api_tests/test_magi_compile.py
@@ -27,7 +27,7 @@ from torch import nn
 from torch.testing import assert_close
 
 from magi_compiler.api import magi_compile
-from magi_compiler.config import CompileConfig, CompileMode
+from magi_compiler.config import CompileConfig
 from tests.perf_tests import cuda_benchmark
 
 
@@ -35,7 +35,7 @@ from tests.perf_tests import cuda_benchmark
 def compile_config_fixture():
     """Fixture to set up a clean compile configuration for each test."""
     cache_dir = tempfile.mkdtemp()
-    compile_config = CompileConfig(compile_mode=CompileMode.TORCH_COMPILE, cache_root_dir=cache_dir)
+    compile_config = CompileConfig(cache_root_dir=cache_dir)
 
     with patch("magi_compiler.config.get_compile_config") as mock_get_config, patch("torch.distributed.get_rank") as mock_rank:
         mock_get_config.return_value = compile_config

--- a/tests/api_tests/test_register_custom_op.py
+++ b/tests/api_tests/test_register_custom_op.py
@@ -33,7 +33,7 @@ from torch import nn
 from torch.testing import assert_close
 
 from magi_compiler.api import magi_compile, magi_register_custom_op
-from magi_compiler.config import CompileConfig, CompileMode
+from magi_compiler.config import CompileConfig
 
 
 class TestBasicRegistration:
@@ -472,7 +472,7 @@ class TestTorchCompileIntegration:
 @pytest.fixture()
 def magi_compile_config():
     """Fixture to set up a clean compile configuration for magi_compile tests."""
-    compile_config = CompileConfig(compile_mode=CompileMode.TORCH_COMPILE, cache_root_dir=tempfile.mkdtemp())
+    compile_config = CompileConfig(cache_root_dir=tempfile.mkdtemp())
 
     with patch("magi_compiler.api.get_compile_config") as mock_get_config, patch("torch.distributed.get_rank") as mock_rank:
         mock_get_config.return_value = compile_config


### PR DESCRIPTION
## 🗂️ PR Category
<!-- Please check the one that applies to this PR using "[x]". -->

- [ ] ✨ New Feature
- [ ] 🚀 Optimization (performance, memory, etc.)
- [ ] 💥 Breaking Change
- [ ] 🐛 Bug Fix
- [ ] 🛠️ Development / Refactoring
- [ ] 📚 Documentation
- [x] 🧹 Chore (Dependencies, CI/CD, Configuration, etc.)
- [x] 🧪 Testing

## 📝 Description
<!-- Please provide a clear description of what this PR does. -->

- Remove explicit CompileMode.TORCH_COMPILE from test fixtures in test_magi_compile.py and test_register_custom_op.py, letting them use the default MAGI_COMPILE mode
- Add a "Check environment (torch & CUDA)" step as the first CI action to fail fast on misconfigured runners

<!-- ## 🔗 Related Issues (Optional) -->
