### PR TITLE
[Dev] Add VAE Inference Example

### DIFF
--- a/example/inference/wan2.2-vae/README.md
+++ b/example/inference/wan2.2-vae/README.md
@@ -1,0 +1,79 @@
+# Conv-Heavy Model Inference Optimization
+
+This example uses WAN 2.2 VAE encode/decode as a representative convolution-heavy inference workload. The scripts feed synthetic tensors with WAN 2.2-compatible shapes, so the case can be profiled without preparing input videos. A real checkpoint can be supplied through `WAN2_2_VAE_PTH`.
+
+## Background
+
+Many generative models contain convolution-heavy submodules, such as video VAEs, image/video decoders, and feature encoders. This example focuses on two common performance issues in PyTorch Inductor generated code:
+
+1. **Convolution layout overhead**: cuDNN channels-last kernels, such as NHWC/NDHWC, are usually faster on Ampere and newer GPUs. If the compiler does not preserve that layout across convolution boundaries, cuDNN can pay repeated internal NC(D)HW to NHWC/NDHWC conversions.
+
+2. **Dynamic-shape memory-kernel tiling overhead**: with dynamic H/W dimensions, the more severe bottleneck often shifts to Inductor's fused Triton kernels for memory-heavy operations around convolutions, such as transpose, permute, reshape, clone, and elementwise layout producers. Symbolic dimensions can make tiling analysis fall back to conservative 1D schedules, leaving these structured memory-operation kernels under-tiled.
+
+WAN 2.2 VAE is used here as a representative benchmark because its encode/decode paths contain stacked 3D convolutions, residual blocks, temporal up/down-sampling, and spatial resampling.
+
+## Optimization Principles
+
+MagiCompiler applies post-grad Inductor graph passes for these two cases.
+
+### Static Conv-Heavy Graphs: Channels-Last Layout
+
+`ConvChannelsLastPass` handles static conv-heavy graphs by taking ownership of convolution layout in FX metadata.
+
+The inserted `aten.clone(memory_format=channels_last)` or `aten.clone(memory_format=channels_last_3d)` is a metadata carrier, not a copy kernel that should survive in the final stream. It lets the pass attach channels-last fake-tensor strides to convolution input and weight nodes.
+
+Inductor's `aten.convolution` lowering already reads input FX meta strides and applies `require_stride_order` to the producer buffers. After the pass rewrites those meta strides to channels-last, Inductor freezes the producer layout as NHWC/NDHWC before cuDNN sees the convolution.
+
+Because the clone lowers as `Pointwise` with `FlexibleLayout`, the stride constraint is normally zero-copy: the producer buffer is allocated directly in channels-last layout instead of emitting an extra clone kernel. With a channels-last input, cuDNN's backend memory-format probe also lets `conv_layout()` infer a channels-last output layout.
+
+### Dynamic H/W Graphs: Triton ND-Tiling Workaround
+
+`ND_TilingWorkaroundPass` targets dynamic H/W graphs where Inductor emits fused Triton kernels for dense memory operations around convolutions.
+
+The goal is to keep these kernels tiled along their natural multi-dimensional structure instead of flattening them into conservative Grid1D-style schedules. The pass enables:
+
+- `prefer_nd_tiling=True`
+- `max_tiles=3`
+- `tile_reductions=True`
+
+The pass is guarded so it only applies when the graph is both dynamic and conv-heavy. In this regime, improving Inductor-generated memory-kernel tiling is often more important than further reducing cuDNN layout conversions.
+
+> This workaround is a targeted fix for the current dynamic-shape behavior. A more general heuristic tiling strategy for these Inductor-generated memory kernels will be added in future work.
+
+## Test Script Usage
+
+Run decode:
+
+```bash
+WAN2_2_VAE_PTH=/path/to/model/Wan2.2_VAE.pth MODE=decode \
+bash example/inference/wan2.2-vae/infer.sh
+```
+
+Run encode:
+
+```bash
+WAN2_2_VAE_PTH=/path/to/model/Wan2.2_VAE.pth MODE=encode \
+bash example/inference/wan2.2-vae/infer.sh
+```
+
+`infer.py` runs one unprofiled `encode`/`decode` call before the NVTX profiled loop to trigger compilation.
+
+By default, `modeling.py` compiles encode/decode with dynamic H/W dimensions enabled through `dynamic_arg_dims={"x": [3, 4]}` and `dynamic_arg_dims={"z": [3, 4]}`. To run the static H/W variant, set those lists to `[]`.
+
+## Performance Comparison
+
+The following numbers are CUDA HW sum averages over profiled iterations on the WAN 2.2 VAE 540p workload, measured on an NVIDIA H100 80G HBM3 GPU. Parentheses show `MAGI_COMPILE` speedup over the corresponding baseline.
+
+### Decode
+
+| Shape mode | MAGI_COMPILE | TORCH_COMPILE | EAGER |
+| --- | ---: | ---: | ---: |
+| Static H/W | `457.943 ms` | `526.973 ms` (`1.15x`) | `855.131 ms` (`1.87x`) |
+| Dynamic H/W | `553.543 ms` | `768.700 ms` (`1.39x`) | `855.131 ms` (`1.54x`) |
+
+### Encode
+
+| Shape mode | MAGI_COMPILE | TORCH_COMPILE | EAGER |
+| --- | ---: | ---: | ---: |
+| Static H/W | `134.444 ms` | `151.183 ms` (`1.12x`) | `269.702 ms` (`2.01x`) |
+| Dynamic H/W | `179.025 ms` | `289.522 ms` (`1.62x`) | `269.702 ms` (`1.51x`) |

--- a/example/inference/wan2.2-vae/README.md
+++ b/example/inference/wan2.2-vae/README.md
@@ -4,39 +4,36 @@ This example uses WAN 2.2 VAE encode/decode as a representative convolution-heav
 
 ## Background
 
-Many generative models contain convolution-heavy submodules, such as video VAEs, image/video decoders, and feature encoders. This example focuses on two common performance issues in PyTorch Inductor generated code:
+Many generative models contain convolution-heavy submodules, such as video VAEs, image/video decoders, and feature encoders. After compilation, these models are usually not executed as convolution kernels alone. The generated workload is commonly a mix of:
 
-1. **Convolution layout overhead**: cuDNN channels-last kernels, such as NHWC/NDHWC, are usually faster on Ampere and newer GPUs. If the compiler does not preserve that layout across convolution boundaries, cuDNN can pay repeated internal NC(D)HW to NHWC/NDHWC conversions.
+- cuDNN convolution kernels for the main convolution computation.
+- Triton fused kernels for memory-heavy operations around convolutions, such as layout changes, reshape, transpose, permute, clone, and elementwise producers.
 
-2. **Dynamic-shape memory-kernel tiling overhead**: with dynamic H/W dimensions, the more severe bottleneck often shifts to Inductor's fused Triton kernels for memory-heavy operations around convolutions, such as transpose, permute, reshape, clone, and elementwise layout producers. Symbolic dimensions can make tiling analysis fall back to conservative 1D schedules, leaving these structured memory-operation kernels under-tiled.
+For this reason, the main bottleneck of a conv-heavy model can change between static-shape and dynamic-shape inference. Static graphs are often limited by repeated cuDNN internal layout conversions, while graphs with dynamic dimensions can become dominated by under-tiled Triton fused memory kernels.
 
 WAN 2.2 VAE is used here as a representative benchmark because its encode/decode paths contain stacked 3D convolutions, residual blocks, temporal up/down-sampling, and spatial resampling.
 
 ## Optimization Principles
 
-MagiCompiler applies post-grad Inductor graph passes for these two cases.
+MagiCompiler optimizes these two cases differently according to where the runtime cost comes from.
 
 ### Static Conv-Heavy Graphs: Channels-Last Layout
 
-`ConvChannelsLastPass` handles static conv-heavy graphs by taking ownership of convolution layout in FX metadata.
+For static shapes, Inductor can usually optimize the surrounding Triton fused memory kernels well because the tensor sizes are known at compile time. In this case, a major remaining cost often comes from repeated layout conversions inside cuDNN convolution calls.
 
-The inserted `aten.clone(memory_format=channels_last)` or `aten.clone(memory_format=channels_last_3d)` is a metadata carrier, not a copy kernel that should survive in the final stream. It lets the pass attach channels-last fake-tensor strides to convolution input and weight nodes.
+cuDNN commonly prefers channels-last layouts, such as NHWC or NDHWC, on Ampere and newer GPUs. If upstream graph nodes produce NC(D)HW tensors, cuDNN may need to convert the input layout internally before running convolution kernels.
 
-Inductor's `aten.convolution` lowering already reads input FX meta strides and applies `require_stride_order` to the producer buffers. After the pass rewrites those meta strides to channels-last, Inductor freezes the producer layout as NHWC/NDHWC before cuDNN sees the convolution.
+MagiCompiler addresses this by arranging channels-last layout on the producer side of the graph. This lets convolution inputs reach cuDNN in the preferred layout, so multiple downstream convolutions can reuse that layout instead of paying repeated internal conversion overhead.
 
-Because the clone lowers as `Pointwise` with `FlexibleLayout`, the stride constraint is normally zero-copy: the producer buffer is allocated directly in channels-last layout instead of emitting an extra clone kernel. With a channels-last input, cuDNN's backend memory-format probe also lets `conv_layout()` infer a channels-last output layout.
+### Dynamic-Shape Graphs: Triton ND-Tiling Workaround
 
-### Dynamic H/W Graphs: Triton ND-Tiling Workaround
+For graphs with dynamic dimensions, the bottleneck often shifts. Symbolic dimensions make it harder for the compiler to choose aggressive multi-dimensional tiling at compile time, so some structured memory operations around convolutions can fall back to more conservative 1D-style schedules.
 
-`ND_TilingWorkaroundPass` targets dynamic H/W graphs where Inductor emits fused Triton kernels for dense memory operations around convolutions.
+In this regime, Triton fused kernels for reshape, transpose, permute, clone, and elementwise layout producers can become a large part of total runtime. Simply moving layout conversions outside cuDNN may increase pressure on these memory-heavy kernels, so the first priority is to improve their tiling behavior.
 
-The goal is to keep these kernels tiled along their natural multi-dimensional structure instead of flattening them into conservative Grid1D-style schedules. The pass enables:
+MagiCompiler addresses this by preserving ND tiling for the memory-heavy kernels around convolutions. This lets reshape, transpose, permute, clone, and elementwise producers execute closer to their natural multi-dimensional tensor structure instead of paying the cost of conservative 1D-style schedules.
 
-- `prefer_nd_tiling=True`
-- `max_tiles=3`
-- `tile_reductions=True`
-
-The pass is guarded so it only applies when the graph is both dynamic and conv-heavy. In this regime, improving Inductor-generated memory-kernel tiling is often more important than further reducing cuDNN layout conversions.
+This optimization is only applied to dynamic conv-heavy graphs, where improving Triton fused memory kernels is often more important than further reducing cuDNN layout conversion overhead.
 
 > This workaround is a targeted fix for the current dynamic-shape behavior. A more general heuristic tiling strategy for these Inductor-generated memory kernels will be added in future work.
 

--- a/example/inference/wan2.2-vae/infer.py
+++ b/example/inference/wan2.2-vae/infer.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026 SandAI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+
+import torch
+from modeling import Wan2_2_VAE
+
+import magi_compiler.utils.nvtx as nvtx
+
+# Set WAN2_2_VAE_PTH=/path/to/model/Wan2.2_VAE.pth to load real weights.
+VAE_PTH = os.environ.get("WAN2_2_VAE_PTH")
+LATENT_SHAPE = [int(x) for x in os.environ.get("LATENT_SHAPE", "48,7,34,60").split(",")]
+MODE = os.environ.get("MODE", "decode")
+PROFILE_CNT = int(os.environ.get("PROFILE_CNT", "3"))
+DTYPE = torch.bfloat16
+
+
+def get_video_shape(latent_shape):
+    _, latent_t, latent_h, latent_w = latent_shape
+    return [3, (latent_t - 1) * 4 + 1, latent_h * 16, latent_w * 16]
+
+
+def run_vae(vae, latent, video):
+    if MODE == "encode":
+        return vae.encode([video])
+    if MODE == "decode":
+        return vae.decode([latent])
+    raise ValueError(f"Unsupported MODE={MODE!r}. Use MODE=encode or MODE=decode.")
+
+
+def main():
+    if not torch.cuda.is_available():
+        raise RuntimeError("WAN 2.2 VAE inference example requires CUDA.")
+
+    torch.random.manual_seed(0)
+
+    vae = Wan2_2_VAE(vae_pth=VAE_PTH, dtype=DTYPE, device="cuda")
+    latent = torch.randn(LATENT_SHAPE, dtype=DTYPE, device=torch.device("cuda"))
+    video_shape = get_video_shape(LATENT_SHAPE)
+    video = torch.randn(video_shape, dtype=DTYPE, device=torch.device("cuda"))
+
+    print(f"Mode: {MODE}")
+    print(f"VAE checkpoint: {'WAN2_2_VAE_PTH' if VAE_PTH else None}")
+    print(f"Latent shape: {LATENT_SHAPE}")
+    print(f"Video shape: {video_shape}")
+
+    # Warm up and trigger compilation.
+    with torch.inference_mode():
+        outputs = run_vae(vae, latent, video)
+    torch.cuda.synchronize()
+
+    for i in range(PROFILE_CNT + 1):
+        nvtx.switch_profile(i, 0, PROFILE_CNT)
+        torch.cuda.synchronize()
+        start = time.perf_counter()
+
+        with torch.inference_mode():
+            outputs = run_vae(vae, latent, video)
+
+        torch.cuda.synchronize()
+        print(f"{MODE} {i}-th image: {time.perf_counter() - start:.4f}s")
+
+    print(f"outputs: {outputs[0].shape}")
+
+
+if __name__ == "__main__":
+    main()

--- a/example/inference/wan2.2-vae/infer.sh
+++ b/example/inference/wan2.2-vae/infer.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright (c) 2026 SandAI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/../../.." &> /dev/null && pwd)
+
+MODE=${MODE:-decode}
+
+if [ "${NSYS_PROFILE:-true}" = "true" ]; then
+    mkdir -p "$PROJECT_ROOT/nsys_reports"
+
+    NSYS_OUTPUT="$PROJECT_ROOT/nsys_reports/nsys_wan2_2_vae_${MODE}_$(date +%Y%m%d_%H%M%S)"
+    echo "${MODE} nsys report: ${NSYS_OUTPUT}.nsys-rep"
+
+    NSYS_CMD="nsys profile --force-overwrite true -o $NSYS_OUTPUT --trace=cuda,nvtx --capture-range=cudaProfilerApi"
+fi
+
+export MAGI_COMPILE_CACHE_ROOT_DIR=${MAGI_COMPILE_CACHE_ROOT_DIR:-"$PROJECT_ROOT/.cache"}
+
+$NSYS_CMD python -u "$SCRIPT_DIR/infer.py" "$@"

--- a/example/inference/wan2.2-vae/modeling.py
+++ b/example/inference/wan2.2-vae/modeling.py
@@ -1,0 +1,857 @@
+# Copyright (c) 2026 SandAI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+import logging
+
+import torch
+import torch.cuda.amp as amp
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange
+
+from magi_compiler import magi_compile
+
+__all__ = ["Wan2_2_VAE"]
+
+CACHE_T = 2
+REP_SENTINEL = "Rep"
+
+
+def _is_rep(x):
+    return isinstance(x, str) and x == REP_SENTINEL
+
+
+class CausalConv3d(nn.Conv3d):
+    """
+    Causal 3d convolusion.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._padding = (self.padding[2], self.padding[2], self.padding[1], self.padding[1], 2 * self.padding[0], 0)
+        self.padding = (0, 0, 0)
+
+    def forward(self, x, cache_x=None):
+        padding = list(self._padding)
+        if cache_x is not None and self._padding[4] > 0:
+            cache_x = cache_x.to(x.device)
+            x = torch.cat([cache_x, x], dim=2)
+            padding[4] -= cache_x.shape[2]
+        x = F.pad(x, padding)
+
+        return super().forward(x)
+
+
+class RMS_norm(nn.Module):
+    def __init__(self, dim, channel_first=True, images=True, bias=False):
+        super().__init__()
+        broadcastable_dims = (1, 1, 1) if not images else (1, 1)
+        shape = (dim, *broadcastable_dims) if channel_first else (dim,)
+
+        self.channel_first = channel_first
+        self.scale = dim**0.5
+        self.gamma = nn.Parameter(torch.ones(shape))
+        self.bias = nn.Parameter(torch.zeros(shape)) if bias else 0.0
+
+    def forward(self, x):
+        return F.normalize(x, dim=(1 if self.channel_first else -1)) * self.scale * self.gamma + self.bias
+
+
+class Upsample(nn.Upsample):
+    def forward(self, x):
+        """
+        Fix bfloat16 support for nearest neighbor interpolation.
+        """
+        return super().forward(x.float()).type_as(x)
+
+
+class Resample(nn.Module):
+    def __init__(self, dim, mode):
+        assert mode in ("none", "upsample2d", "upsample3d", "downsample2d", "downsample3d")
+        super().__init__()
+        self.dim = dim
+        self.mode = mode
+
+        # layers
+        if mode == "upsample2d":
+            self.resample = nn.Sequential(
+                Upsample(scale_factor=(2.0, 2.0), mode="nearest-exact"), nn.Conv2d(dim, dim, 3, padding=1)
+            )
+        elif mode == "upsample3d":
+            self.resample = nn.Sequential(
+                Upsample(scale_factor=(2.0, 2.0), mode="nearest-exact"),
+                nn.Conv2d(dim, dim, 3, padding=1),
+                # nn.Conv2d(dim, dim//2, 3, padding=1)
+            )
+            self.time_conv = CausalConv3d(dim, dim * 2, (3, 1, 1), padding=(1, 0, 0))
+        elif mode == "downsample2d":
+            self.resample = nn.Sequential(nn.ZeroPad2d((0, 1, 0, 1)), nn.Conv2d(dim, dim, 3, stride=(2, 2)))
+        elif mode == "downsample3d":
+            self.resample = nn.Sequential(nn.ZeroPad2d((0, 1, 0, 1)), nn.Conv2d(dim, dim, 3, stride=(2, 2)))
+            self.time_conv = CausalConv3d(dim, dim, (3, 1, 1), stride=(2, 1, 1), padding=(0, 0, 0))
+        else:
+            self.resample = nn.Identity()
+
+    def forward(self, x, feat_cache=None, feat_idx=[0]):
+        b, c, t, h, w = x.size()
+        if self.mode == "upsample3d":
+            if feat_cache is not None:
+                idx = feat_idx[0]
+                if feat_cache[idx] is None:
+                    feat_cache[idx] = REP_SENTINEL
+                    feat_idx[0] += 1
+                else:
+                    cache_x = x[:, :, -CACHE_T:, :, :].clone()
+                    if cache_x.shape[2] < 2 and feat_cache[idx] is not None and not _is_rep(feat_cache[idx]):
+                        # cache last frame of last two chunk
+                        cache_x = torch.cat([feat_cache[idx][:, :, -1, :, :].unsqueeze(2).to(cache_x.device), cache_x], dim=2)
+                    if cache_x.shape[2] < 2 and feat_cache[idx] is not None and _is_rep(feat_cache[idx]):
+                        cache_x = torch.cat([torch.zeros_like(cache_x).to(cache_x.device), cache_x], dim=2)
+                    if _is_rep(feat_cache[idx]):
+                        x = self.time_conv(x)
+                    else:
+                        x = self.time_conv(x, feat_cache[idx])
+                    feat_cache[idx] = cache_x
+                    feat_idx[0] += 1
+                    x = x.reshape(b, 2, c, t, h, w)
+                    x = torch.stack((x[:, 0, :, :, :, :], x[:, 1, :, :, :, :]), 3)
+                    x = x.reshape(b, c, t * 2, h, w)
+        t = x.shape[2]
+        x = rearrange(x, "b c t h w -> (b t) c h w")
+        x = self.resample(x)
+        x = rearrange(x, "(b t) c h w -> b c t h w", t=t)
+
+        if self.mode == "downsample3d":
+            if feat_cache is not None:
+                idx = feat_idx[0]
+                if feat_cache[idx] is None:
+                    feat_cache[idx] = x.clone()
+                    feat_idx[0] += 1
+                else:
+                    cache_x = x[:, :, -1:, :, :].clone()
+                    x = self.time_conv(torch.cat([feat_cache[idx][:, :, -1:, :, :], x], 2))
+                    feat_cache[idx] = cache_x
+                    feat_idx[0] += 1
+        return x
+
+    def init_weight(self, conv):
+        conv_weight = conv.weight.detach().clone()
+        nn.init.zeros_(conv_weight)
+        c1, c2, t, h, w = conv_weight.size()
+        one_matrix = torch.eye(c1, c2)
+        init_matrix = one_matrix
+        nn.init.zeros_(conv_weight)
+        conv_weight.data[:, :, 1, 0, 0] = init_matrix  # * 0.5
+        conv.weight = nn.Parameter(conv_weight)
+        nn.init.zeros_(conv.bias.data)
+
+    def init_weight2(self, conv):
+        conv_weight = conv.weight.data.detach().clone()
+        nn.init.zeros_(conv_weight)
+        c1, c2, t, h, w = conv_weight.size()
+        init_matrix = torch.eye(c1 // 2, c2)
+        conv_weight[: c1 // 2, :, -1, 0, 0] = init_matrix
+        conv_weight[c1 // 2 :, :, -1, 0, 0] = init_matrix
+        conv.weight = nn.Parameter(conv_weight)
+        nn.init.zeros_(conv.bias.data)
+
+
+class ResidualBlock(nn.Module):
+    def __init__(self, in_dim, out_dim, dropout=0.0):
+        super().__init__()
+        self.in_dim = in_dim
+        self.out_dim = out_dim
+
+        # layers
+        self.residual = nn.Sequential(
+            RMS_norm(in_dim, images=False),
+            nn.SiLU(),
+            CausalConv3d(in_dim, out_dim, 3, padding=1),
+            RMS_norm(out_dim, images=False),
+            nn.SiLU(),
+            nn.Dropout(dropout),
+            CausalConv3d(out_dim, out_dim, 3, padding=1),
+        )
+        self.shortcut = CausalConv3d(in_dim, out_dim, 1) if in_dim != out_dim else nn.Identity()
+
+    def forward(self, x, feat_cache=None, feat_idx=[0]):
+        h = self.shortcut(x)
+        for layer in self.residual:
+            if isinstance(layer, CausalConv3d) and feat_cache is not None:
+                idx = feat_idx[0]
+                cache_x = x[:, :, -CACHE_T:, :, :].clone()
+                if cache_x.shape[2] < 2 and feat_cache[idx] is not None:
+                    # cache last frame of last two chunk
+                    cache_x = torch.cat([feat_cache[idx][:, :, -1, :, :].unsqueeze(2).to(cache_x.device), cache_x], dim=2)
+                x = layer(x, feat_cache[idx])
+                feat_cache[idx] = cache_x
+                feat_idx[0] += 1
+            else:
+                x = layer(x)
+        return x + h
+
+
+class AttentionBlock(nn.Module):
+    """
+    Causal self-attention with a single head.
+    """
+
+    def __init__(self, dim):
+        super().__init__()
+        self.dim = dim
+
+        # layers
+        self.norm = RMS_norm(dim)
+        self.to_qkv = nn.Conv2d(dim, dim * 3, 1)
+        self.proj = nn.Conv2d(dim, dim, 1)
+
+        # zero out the last layer params
+        nn.init.zeros_(self.proj.weight)
+
+    def forward(self, x):
+        identity = x
+        b, c, t, h, w = x.size()
+        x = rearrange(x, "b c t h w -> (b t) c h w")
+        x = self.norm(x)
+        # compute query, key, value
+        q, k, v = self.to_qkv(x).reshape(b * t, 1, c * 3, -1).permute(0, 1, 3, 2).contiguous().chunk(3, dim=-1)
+
+        # apply attention
+        x = F.scaled_dot_product_attention(q, k, v)
+        x = x.squeeze(1).permute(0, 2, 1).reshape(b * t, c, h, w)
+
+        # output
+        x = self.proj(x)
+        x = rearrange(x, "(b t) c h w-> b c t h w", t=t)
+        return x + identity
+
+
+def patchify(x, patch_size):
+    if patch_size == 1:
+        return x
+    if x.dim() == 4:
+        x = rearrange(x, "b c (h q) (w r) -> b (c r q) h w", q=patch_size, r=patch_size)
+    elif x.dim() == 5:
+        x = rearrange(x, "b c f (h q) (w r) -> b (c r q) f h w", q=patch_size, r=patch_size)
+    else:
+        raise ValueError(f"Invalid input shape: {x.shape}")
+
+    return x
+
+
+def unpatchify(x, patch_size):
+    if patch_size == 1:
+        return x
+
+    if x.dim() == 4:
+        x = rearrange(x, "b (c r q) h w -> b c (h q) (w r)", q=patch_size, r=patch_size)
+    elif x.dim() == 5:
+        x = rearrange(x, "b (c r q) f h w -> b c f (h q) (w r)", q=patch_size, r=patch_size)
+    return x
+
+
+class AvgDown3D(nn.Module):
+    def __init__(self, in_channels, out_channels, factor_t, factor_s=1):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.factor_t = factor_t
+        self.factor_s = factor_s
+        self.factor = self.factor_t * self.factor_s * self.factor_s
+
+        assert in_channels * self.factor % out_channels == 0
+        self.group_size = in_channels * self.factor // out_channels
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        pad_t = (self.factor_t - x.shape[2] % self.factor_t) % self.factor_t
+        pad = (0, 0, 0, 0, pad_t, 0)
+        x = F.pad(x, pad)
+        B, C, T, H, W = x.shape
+        x = x.view(
+            B, C, T // self.factor_t, self.factor_t, H // self.factor_s, self.factor_s, W // self.factor_s, self.factor_s
+        )
+        x = x.permute(0, 1, 3, 5, 7, 2, 4, 6).contiguous()
+        x = x.view(B, C * self.factor, T // self.factor_t, H // self.factor_s, W // self.factor_s)
+        x = x.view(B, self.out_channels, self.group_size, T // self.factor_t, H // self.factor_s, W // self.factor_s)
+        x = x.mean(dim=2)
+        return x
+
+
+class DupUp3D(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int, factor_t, factor_s=1):
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+
+        self.factor_t = factor_t
+        self.factor_s = factor_s
+        self.factor = self.factor_t * self.factor_s * self.factor_s
+
+        assert out_channels * self.factor % in_channels == 0
+        self.repeats = out_channels * self.factor // in_channels
+
+    def forward(self, x: torch.Tensor, first_chunk=False) -> torch.Tensor:
+        x = x.repeat_interleave(self.repeats, dim=1)
+        x = x.view(x.size(0), self.out_channels, self.factor_t, self.factor_s, self.factor_s, x.size(2), x.size(3), x.size(4))
+        x = x.permute(0, 1, 5, 2, 6, 3, 7, 4).contiguous()
+        x = x.view(
+            x.size(0), self.out_channels, x.size(2) * self.factor_t, x.size(4) * self.factor_s, x.size(6) * self.factor_s
+        )
+        if first_chunk:
+            x = x[:, :, self.factor_t - 1 :, :, :]
+        return x
+
+
+class Down_ResidualBlock(nn.Module):
+    def __init__(self, in_dim, out_dim, dropout, mult, temperal_downsample=False, down_flag=False):
+        super().__init__()
+
+        # Shortcut path with downsample
+        self.avg_shortcut = AvgDown3D(
+            in_dim, out_dim, factor_t=2 if temperal_downsample else 1, factor_s=2 if down_flag else 1
+        )
+
+        # Main path with residual blocks and downsample
+        downsamples = []
+        for _ in range(mult):
+            downsamples.append(ResidualBlock(in_dim, out_dim, dropout))
+            in_dim = out_dim
+
+        # Add the final downsample block
+        if down_flag:
+            mode = "downsample3d" if temperal_downsample else "downsample2d"
+            downsamples.append(Resample(out_dim, mode=mode))
+
+        self.downsamples = nn.Sequential(*downsamples)
+
+    def forward(self, x, feat_cache=None, feat_idx=[0]):
+        x_copy = x.clone()
+        for module in self.downsamples:
+            x = module(x, feat_cache, feat_idx)
+
+        return x + self.avg_shortcut(x_copy)
+
+
+class Up_ResidualBlock(nn.Module):
+    def __init__(self, in_dim, out_dim, dropout, mult, temperal_upsample=False, up_flag=False):
+        super().__init__()
+        # Shortcut path with upsample
+        if up_flag:
+            self.avg_shortcut = DupUp3D(in_dim, out_dim, factor_t=2 if temperal_upsample else 1, factor_s=2 if up_flag else 1)
+        else:
+            self.avg_shortcut = None
+
+        # Main path with residual blocks and upsample
+        upsamples = []
+        for _ in range(mult):
+            upsamples.append(ResidualBlock(in_dim, out_dim, dropout))
+            in_dim = out_dim
+
+        # Add the final upsample block
+        if up_flag:
+            mode = "upsample3d" if temperal_upsample else "upsample2d"
+            upsamples.append(Resample(out_dim, mode=mode))
+
+        self.upsamples = nn.Sequential(*upsamples)
+
+    def forward(self, x, feat_cache=None, feat_idx=[0], first_chunk=False):
+        x_main = x.clone()
+        for module in self.upsamples:
+            x_main = module(x_main, feat_cache, feat_idx)
+        if self.avg_shortcut is not None:
+            x_shortcut = self.avg_shortcut(x, first_chunk)
+            return x_main + x_shortcut
+        else:
+            return x_main
+
+
+class Encoder3d(nn.Module):
+    def __init__(
+        self,
+        dim=128,
+        z_dim=4,
+        dim_mult=[1, 2, 4, 4],
+        num_res_blocks=2,
+        attn_scales=[],
+        temperal_downsample=[True, True, False],
+        dropout=0.0,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.z_dim = z_dim
+        self.dim_mult = dim_mult
+        self.num_res_blocks = num_res_blocks
+        self.attn_scales = attn_scales
+        self.temperal_downsample = temperal_downsample
+
+        # dimensions
+        dims = [dim * u for u in [1] + dim_mult]
+        scale = 1.0
+
+        # init block
+        self.conv1 = CausalConv3d(12, dims[0], 3, padding=1)
+
+        # downsample blocks
+        downsamples = []
+        for i, (in_dim, out_dim) in enumerate(zip(dims[:-1], dims[1:])):
+            t_down_flag = temperal_downsample[i] if i < len(temperal_downsample) else False
+            downsamples.append(
+                Down_ResidualBlock(
+                    in_dim=in_dim,
+                    out_dim=out_dim,
+                    dropout=dropout,
+                    mult=num_res_blocks,
+                    temperal_downsample=t_down_flag,
+                    down_flag=i != len(dim_mult) - 1,
+                )
+            )
+            scale /= 2.0
+        self.downsamples = nn.Sequential(*downsamples)
+
+        # middle blocks
+        self.middle = nn.Sequential(
+            ResidualBlock(out_dim, out_dim, dropout), AttentionBlock(out_dim), ResidualBlock(out_dim, out_dim, dropout)
+        )
+
+        # # output blocks
+        self.head = nn.Sequential(RMS_norm(out_dim, images=False), nn.SiLU(), CausalConv3d(out_dim, z_dim, 3, padding=1))
+
+    def forward(self, x, feat_cache=None, feat_idx=[0]):
+        if feat_cache is not None:
+            idx = feat_idx[0]
+            cache_x = x[:, :, -CACHE_T:, :, :].clone()
+            if cache_x.shape[2] < 2 and feat_cache[idx] is not None:
+                cache_x = torch.cat([feat_cache[idx][:, :, -1, :, :].unsqueeze(2).to(cache_x.device), cache_x], dim=2)
+            x = self.conv1(x, feat_cache[idx])
+            feat_cache[idx] = cache_x
+            feat_idx[0] += 1
+        else:
+            x = self.conv1(x)
+
+        ## downsamples
+        for layer in self.downsamples:
+            if feat_cache is not None:
+                x = layer(x, feat_cache, feat_idx)
+            else:
+                x = layer(x)
+
+        ## middle
+        for layer in self.middle:
+            if isinstance(layer, ResidualBlock) and feat_cache is not None:
+                x = layer(x, feat_cache, feat_idx)
+            else:
+                x = layer(x)
+
+        ## head
+        for layer in self.head:
+            if isinstance(layer, CausalConv3d) and feat_cache is not None:
+                idx = feat_idx[0]
+                cache_x = x[:, :, -CACHE_T:, :, :].clone()
+                if cache_x.shape[2] < 2 and feat_cache[idx] is not None:
+                    cache_x = torch.cat([feat_cache[idx][:, :, -1, :, :].unsqueeze(2).to(cache_x.device), cache_x], dim=2)
+                x = layer(x, feat_cache[idx])
+                feat_cache[idx] = cache_x
+                feat_idx[0] += 1
+            else:
+                x = layer(x)
+
+        return x
+
+
+class Decoder3d(nn.Module):
+    def __init__(
+        self,
+        dim=128,
+        z_dim=4,
+        dim_mult=[1, 2, 4, 4],
+        num_res_blocks=2,
+        attn_scales=[],
+        temperal_upsample=[False, True, True],
+        dropout=0.0,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.z_dim = z_dim
+        self.dim_mult = dim_mult
+        self.num_res_blocks = num_res_blocks
+        self.attn_scales = attn_scales
+        self.temperal_upsample = temperal_upsample
+
+        # dimensions
+        dims = [dim * u for u in [dim_mult[-1]] + dim_mult[::-1]]
+        1.0 / 2 ** (len(dim_mult) - 2)
+        # init block
+        self.conv1 = CausalConv3d(z_dim, dims[0], 3, padding=1)
+
+        # middle blocks
+        self.middle = nn.Sequential(
+            ResidualBlock(dims[0], dims[0], dropout), AttentionBlock(dims[0]), ResidualBlock(dims[0], dims[0], dropout)
+        )
+
+        # upsample blocks
+        upsamples = []
+        for i, (in_dim, out_dim) in enumerate(zip(dims[:-1], dims[1:])):
+            t_up_flag = temperal_upsample[i] if i < len(temperal_upsample) else False
+            upsamples.append(
+                Up_ResidualBlock(
+                    in_dim=in_dim,
+                    out_dim=out_dim,
+                    dropout=dropout,
+                    mult=num_res_blocks + 1,
+                    temperal_upsample=t_up_flag,
+                    up_flag=i != len(dim_mult) - 1,
+                )
+            )
+        self.upsamples = nn.Sequential(*upsamples)
+
+        # output blocks
+        self.head = nn.Sequential(RMS_norm(out_dim, images=False), nn.SiLU(), CausalConv3d(out_dim, 12, 3, padding=1))
+
+    def forward(self, x, feat_cache=None, feat_idx=[0], first_chunk=False):
+        if feat_cache is not None:
+            idx = feat_idx[0]
+            cache_x = x[:, :, -CACHE_T:, :, :].clone()
+            if cache_x.shape[2] < 2 and feat_cache[idx] is not None:
+                cache_x = torch.cat([feat_cache[idx][:, :, -1, :, :].unsqueeze(2).to(cache_x.device), cache_x], dim=2)
+            x = self.conv1(x, feat_cache[idx])
+            feat_cache[idx] = cache_x
+            feat_idx[0] += 1
+        else:
+            x = self.conv1(x)
+
+        for layer in self.middle:
+            if isinstance(layer, ResidualBlock) and feat_cache is not None:
+                x = layer(x, feat_cache, feat_idx)
+            else:
+                x = layer(x)
+
+        ## upsamples
+        for layer in self.upsamples:
+            if feat_cache is not None:
+                x = layer(x, feat_cache, feat_idx, first_chunk)
+            else:
+                x = layer(x)
+
+        ## head
+        for layer in self.head:
+            if isinstance(layer, CausalConv3d) and feat_cache is not None:
+                idx = feat_idx[0]
+                cache_x = x[:, :, -CACHE_T:, :, :].clone()
+                if cache_x.shape[2] < 2 and feat_cache[idx] is not None:
+                    cache_x = torch.cat([feat_cache[idx][:, :, -1, :, :].unsqueeze(2).to(cache_x.device), cache_x], dim=2)
+                x = layer(x, feat_cache[idx])
+                feat_cache[idx] = cache_x
+                feat_idx[0] += 1
+            else:
+                x = layer(x)
+        return x
+
+
+def count_conv3d(model):
+    count = 0
+    for m in model.modules():
+        if isinstance(m, CausalConv3d):
+            count += 1
+    return count
+
+
+class WanVAE_(nn.Module):
+    def __init__(
+        self,
+        dim=160,
+        dec_dim=256,
+        z_dim=16,
+        dim_mult=[1, 2, 4, 4],
+        num_res_blocks=2,
+        attn_scales=[],
+        temperal_downsample=[True, True, False],
+        dropout=0.0,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.z_dim = z_dim
+        self.dim_mult = dim_mult
+        self.num_res_blocks = num_res_blocks
+        self.attn_scales = attn_scales
+        self.temperal_downsample = temperal_downsample
+        self.temperal_upsample = temperal_downsample[::-1]
+
+        # modules
+        self.encoder = Encoder3d(dim, z_dim * 2, dim_mult, num_res_blocks, attn_scales, self.temperal_downsample, dropout)
+        self.conv1 = CausalConv3d(z_dim * 2, z_dim * 2, 1)
+        self.conv2 = CausalConv3d(z_dim, z_dim, 1)
+        self.decoder = Decoder3d(dec_dim, z_dim, dim_mult, num_res_blocks, attn_scales, self.temperal_upsample, dropout)
+
+    def forward(self, x, scale=[0, 1]):
+        mu = self.encode(x, scale)
+        x_recon = self.decode(mu, scale)
+        return x_recon, mu
+
+    def encode(self, x, scale):
+        self.clear_cache()
+        x = patchify(x, patch_size=2)
+        t = x.shape[2]
+        iter_ = 1 + (t - 1) // 4
+        for i in range(iter_):
+            self._enc_conv_idx = [0]
+            if i == 0:
+                out = self.encoder(x[:, :, :1, :, :], feat_cache=self._enc_feat_map, feat_idx=self._enc_conv_idx)
+            else:
+                out_ = self.encoder(
+                    x[:, :, 1 + 4 * (i - 1) : 1 + 4 * i, :, :], feat_cache=self._enc_feat_map, feat_idx=self._enc_conv_idx
+                )
+                out = torch.cat([out, out_], 2)
+        mu, log_var = self.conv1(out).chunk(2, dim=1)
+        if isinstance(scale[0], torch.Tensor):
+            mu = (mu - scale[0].view(1, self.z_dim, 1, 1, 1)) * scale[1].view(1, self.z_dim, 1, 1, 1)
+        else:
+            mu = (mu - scale[0]) * scale[1]
+        self.clear_cache()
+        return mu
+
+    def decode(self, z, scale):
+        self.clear_cache()
+        if isinstance(scale[0], torch.Tensor):
+            z = z / scale[1].view(1, self.z_dim, 1, 1, 1) + scale[0].view(1, self.z_dim, 1, 1, 1)
+        else:
+            z = z / scale[1] + scale[0]
+        iter_ = z.shape[2]
+        x = self.conv2(z)
+        for i in range(iter_):
+            self._conv_idx = [0]
+            if i == 0:
+                out = self.decoder(
+                    x[:, :, i : i + 1, :, :], feat_cache=self._feat_map, feat_idx=self._conv_idx, first_chunk=True
+                )
+            else:
+                out_ = self.decoder(x[:, :, i : i + 1, :, :], feat_cache=self._feat_map, feat_idx=self._conv_idx)
+                out = torch.cat([out, out_], 2)
+        out = unpatchify(out, patch_size=2)
+        self.clear_cache()
+        return out
+
+    def reparameterize(self, mu, log_var):
+        std = torch.exp(0.5 * log_var)
+        eps = torch.randn_like(std)
+        return eps * std + mu
+
+    def sample(self, imgs, deterministic=False):
+        mu, log_var = self.encode(imgs)
+        if deterministic:
+            return mu
+        std = torch.exp(0.5 * log_var.clamp(-30.0, 20.0))
+        return mu + std * torch.randn_like(std)
+
+    def clear_cache(self):
+        self._conv_num = count_conv3d(self.decoder)
+        self._conv_idx = [0]
+        self._feat_map = [None] * self._conv_num
+        # cache encode
+        self._enc_conv_num = count_conv3d(self.encoder)
+        self._enc_conv_idx = [0]
+        self._enc_feat_map = [None] * self._enc_conv_num
+
+
+def _video_vae(pretrained_path=None, z_dim=16, dim=160, device="cpu", **kwargs):
+    # params
+    cfg = dict(
+        dim=dim,
+        z_dim=z_dim,
+        dim_mult=[1, 2, 4, 4],
+        num_res_blocks=2,
+        attn_scales=[],
+        temperal_downsample=[True, True, True],
+        dropout=0.0,
+    )
+    cfg.update(**kwargs)
+
+    # init model
+    if pretrained_path is None:
+        logging.warning("No VAE checkpoint was provided; using randomly initialized weights.")
+        return WanVAE_(**cfg)
+
+    with torch.device("meta"):
+        model = WanVAE_(**cfg)
+
+    # load checkpoint
+    logging.info("loading WAN 2.2 VAE checkpoint from configured path")
+    model.load_state_dict(torch.load(pretrained_path, map_location=device), assign=True)
+
+    return model
+
+
+class Wan2_2_VAE:
+    def __init__(
+        self,
+        z_dim=48,
+        c_dim=160,
+        vae_pth=None,
+        dim_mult=[1, 2, 4, 4],
+        temperal_downsample=[False, True, True],
+        dtype=torch.float,
+        device="cuda",
+    ):
+        self.dtype = dtype
+        self.device = device
+
+        mean = torch.tensor(
+            [
+                -0.2289,
+                -0.0052,
+                -0.1323,
+                -0.2339,
+                -0.2799,
+                0.0174,
+                0.1838,
+                0.1557,
+                -0.1382,
+                0.0542,
+                0.2813,
+                0.0891,
+                0.1570,
+                -0.0098,
+                0.0375,
+                -0.1825,
+                -0.2246,
+                -0.1207,
+                -0.0698,
+                0.5109,
+                0.2665,
+                -0.2108,
+                -0.2158,
+                0.2502,
+                -0.2055,
+                -0.0322,
+                0.1109,
+                0.1567,
+                -0.0729,
+                0.0899,
+                -0.2799,
+                -0.1230,
+                -0.0313,
+                -0.1649,
+                0.0117,
+                0.0723,
+                -0.2839,
+                -0.2083,
+                -0.0520,
+                0.3748,
+                0.0152,
+                0.1957,
+                0.1433,
+                -0.2944,
+                0.3573,
+                -0.0548,
+                -0.1681,
+                -0.0667,
+            ],
+            dtype=dtype,
+            device=device,
+        )
+        std = torch.tensor(
+            [
+                0.4765,
+                1.0364,
+                0.4514,
+                1.1677,
+                0.5313,
+                0.4990,
+                0.4818,
+                0.5013,
+                0.8158,
+                1.0344,
+                0.5894,
+                1.0901,
+                0.6885,
+                0.6165,
+                0.8454,
+                0.4978,
+                0.5759,
+                0.3523,
+                0.7135,
+                0.6804,
+                0.5833,
+                1.4146,
+                0.8986,
+                0.5659,
+                0.7069,
+                0.5338,
+                0.4889,
+                0.4917,
+                0.4069,
+                0.4999,
+                0.6866,
+                0.4093,
+                0.5709,
+                0.6065,
+                0.6415,
+                0.4944,
+                0.5726,
+                1.2042,
+                0.5458,
+                1.6887,
+                0.3971,
+                1.0600,
+                0.3943,
+                0.5537,
+                0.5444,
+                0.4089,
+                0.7468,
+                0.7744,
+            ],
+            dtype=dtype,
+            device=device,
+        )
+        self.scale = [mean, 1.0 / std]
+
+        # init model
+        self.model = (
+            _video_vae(
+                pretrained_path=vae_pth, z_dim=z_dim, dim=c_dim, dim_mult=dim_mult, temperal_downsample=temperal_downsample
+            )
+            .eval()
+            .requires_grad_(False)
+            .to(device)
+        )
+        self.model.encode = magi_compile(
+            self.model.encode,
+            model_tag="wan2_2_vae_encode",
+            dynamic_arg_dims={"x": [3, 4]},  # If static arg dims, set `dynamic_arg_dims={"x": []}`
+        )
+        self.model.decode = magi_compile(
+            self.model.decode,
+            model_tag="wan2_2_vae_decode",
+            dynamic_arg_dims={"z": [3, 4]},  # If static arg dims, set `dynamic_arg_dims={"x": []}`
+        )
+
+    def encode(self, videos):
+        try:
+            if not isinstance(videos, list):
+                raise TypeError("videos should be a list")
+            with amp.autocast(dtype=self.dtype):
+                return [self.model.encode(u.unsqueeze(0), self.scale).float().squeeze(0) for u in videos]
+        except TypeError as e:
+            logging.info(e)
+            return None
+
+    def decode(self, zs):
+        try:
+            if not isinstance(zs, list):
+                raise TypeError("zs should be a list")
+            with amp.autocast(dtype=self.dtype):
+                return [self.model.decode(u.unsqueeze(0), self.scale).float().clamp_(-1, 1).squeeze(0) for u in zs]
+        except TypeError as e:
+            logging.info(e)
+            return None

--- a/magi_compiler/passes/piecewise_graph/nd_tiling_workaround.py
+++ b/magi_compiler/passes/piecewise_graph/nd_tiling_workaround.py
@@ -16,7 +16,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import torch
-from torch.torch_version import TorchVersion
 
 from ...magi_depyf.timeline import emit_pass_lifecycle
 from ..pass_base import MagiInductorPass
@@ -29,19 +28,14 @@ class ND_TilingWorkaroundPass(MagiInductorPass):
         "triton.tile_reductions",
     )
 
-    def __init__(self):
-        super().__init__()
-        self.is_target_torch_version = TorchVersion(torch.__version__) < (2, 11, 0)
-
     @emit_pass_lifecycle
     def __call__(self, graph: torch.fx.Graph):
-        if not self.is_target_torch_version or not self.is_dynamic(graph) or not self.is_conv_heavy(graph):
+        if not self.is_dynamic(graph) or not self.is_conv_heavy(graph):
             return False
 
-        # On PyTorch < 2.11.0, Inductor's coalesce tiling analysis bails out on
-        # symbolic numels, so dynamic-shape transpose/permute/channels-last kernels
-        # degrade to untiled Grid1D. Forcing prefer_nd_tiling restores ND tiling
-        # (WAN 2.2 VAE 540p decode: ~1.45x).
+        # Inductor's coalesce tiling analysis bails out on symbolic numels, so
+        # dynamic-shape transpose/permute/channels-last kernels degrade to untiled Grid1D.
+        # Forcing prefer_nd_tiling restores ND tiling.
         torch._inductor.config.triton.prefer_nd_tiling = True
         torch._inductor.config.triton.max_tiles = 3
         torch._inductor.config.triton.tile_reductions = True

--- a/tests/feature_tests/test_nd_tiling_workaround.py
+++ b/tests/feature_tests/test_nd_tiling_workaround.py
@@ -19,7 +19,7 @@ When applicable, the pass flips three ``torch._inductor.config`` triton keys
 ``enable_nd_tiling_workaround`` config controls registration:
 
   * ``True`` (default) -> register the pass; its internal heuristics then decide:
-    apply iff dynamic shapes AND PyTorch < 2.11.0 AND conv-heavy.
+    apply iff dynamic shapes AND conv-heavy.
   * ``False`` -> pass not registered at all.
 
 These tests assert the registered pass's heuristic decision. The shared
@@ -51,19 +51,6 @@ def _restore_inductor_config():
         cfg.triton.prefer_nd_tiling, cfg.triton.max_tiles, cfg.triton.tile_reductions = saved
 
 
-def _make_pass(*, is_target_torch_version=True):
-    """Build the pass and pin its version gate.
-
-    The pass reads ``torch.__version__`` at construction and caches whether it is
-    a target version (< 2.11.0) in ``is_target_torch_version``. Tests override that
-    cached flag directly so the version branch is exercised regardless of the
-    installed torch.
-    """
-    pass_ = ND_TilingWorkaroundPass()
-    pass_.is_target_torch_version = is_target_torch_version
-    return pass_
-
-
 def _assert_injected(injected):
     cfg = torch._inductor.config
     if injected:
@@ -88,30 +75,22 @@ def test_config_field_binary(value):
 
 
 def test_auto_injects_when_all_conditions_met(fake_mode):
-    pass_ = _make_pass(is_target_torch_version=True)
+    pass_ = ND_TilingWorkaroundPass()
     gm = _auto_eligible_graph(fake_mode)
     pass_(gm.graph)
     _assert_injected(True)
 
 
 def test_auto_skips_on_static_shapes(fake_mode):
-    pass_ = _make_pass(is_target_torch_version=True)
+    pass_ = ND_TilingWorkaroundPass()
     gm = build_graph_module(fake_mode, placeholder_vals=[static_tensor(fake_mode)], n_conv=0, n_filler=5)
-    pass_(gm.graph)
-    _assert_injected(False)
-
-
-def test_auto_skips_on_fixed_version(fake_mode):
-    """Dynamic shapes but PyTorch >= 2.11.0: native coalesce path handles it."""
-    pass_ = _make_pass(is_target_torch_version=False)
-    gm = _auto_eligible_graph(fake_mode)
     pass_(gm.graph)
     _assert_injected(False)
 
 
 def test_auto_skips_when_graph_not_conv_heavy(fake_mode):
     """``nnodes >= 300 * nconv`` (conv-sparse graph): low conv ratio, ND-tiling gives little, so skip."""
-    pass_ = _make_pass(is_target_torch_version=True)
+    pass_ = ND_TilingWorkaroundPass()
     gm = build_graph_module(fake_mode, placeholder_vals=[dynamic_tensor(fake_mode)], n_conv=1, n_filler=320)
     pass_(gm.graph)
     _assert_injected(False)

--- a/tests/perf_tests/test_nd_tiling_perf_workaround.py
+++ b/tests/perf_tests/test_nd_tiling_perf_workaround.py
@@ -16,8 +16,8 @@
 
 Background
 ----------
-On PyTorch < 2.11.0, Inductor's coalesce tiling analysis bails out on symbolic
-numels (``tiling_utils.extract_normalized_read_writes`` returns ``None``), so
+Inductor's coalesce tiling analysis can bail out on symbolic numels
+(``tiling_utils.extract_normalized_read_writes`` returns ``None``), so
 transpose/permute/channels-last pointwise kernels in a dynamic-shape graph
 degrade to untiled Grid1D. ``ND_TilingWorkaroundPass`` works around this by
 enabling ``triton.prefer_nd_tiling`` (+ ``max_tiles=3`` + ``tile_reductions``)


### PR DESCRIPTION
## 🗂️ PR Category

- [ ] ✨ New Feature
- [ ] 🚀 Optimization (performance, memory, etc.)
- [ ] 💥 Breaking Change
- [ ] 🐛 Bug Fix
- [x] 🛠️ Development / Refactoring
- [ ] 📚 Documentation
- [ ] 🧹 Chore (Dependencies, CI/CD, Configuration, etc.)
- [ ] 🧪 Testing

## 📝 Description
This PR only adds the WAN 2.2 VAE inference benchmark/example for measuring the performance impact of the optimization passes introduced in previous PRs.

The following numbers are CUDA HW sum averages over profiled iterations on the WAN 2.2 VAE 540p workload, measured on an NVIDIA H100 80G HBM3 GPU. Parentheses show MagiCompiler speedup over the corresponding baseline.

### Decode

| Shape mode | MAGI_COMPILE | TORCH_COMPILE | EAGER |
| --- | ---: | ---: | ---: |
| Static H/W | `457.943 ms` | `526.973 ms` (`1.15x`) | `855.131 ms` (`1.87x`) |
| Dynamic H/W | `553.543 ms` | `768.700 ms` (`1.39x`) | `855.131 ms` (`1.54x`) |

### Encode

| Shape mode | MAGI_COMPILE | TORCH_COMPILE | EAGER |
| --- | ---: | ---: | ---: |
| Static H/W | `134.444 ms` | `151.183 ms` (`1.12x`) | `269.702 ms` (`2.01x`) |
| Dynamic H/W | `179.025 ms` | `289.522 ms` (`1.62x`) | `269.702 ms` (`1.51x`) |