### PR TITLE
[Fix] Include parallel topology in cache directory to prevent cross-contamination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+.tmp/

--- a/magi_compiler/config.py
+++ b/magi_compiler/config.py
@@ -387,19 +387,19 @@ class CompileConfig(BaseSettings):
 def _get_parallel_topology() -> str:
     """Return a compact topology string for compile-cache keying.
 
-    Delegates to PSM.topology_key() which encodes all leaf parallel dimensions
-    (tp, cp, ep, dp, pp, etc.) -- different topologies produce different tensor
-    strides in custom-op meta functions and must not share cached artifacts.
+    Different parallel topologies produce different tensor strides in custom-op
+    meta functions and must not share cached artifacts.
+
+    Resolution order:
+    1. ``MAGI_COMPILE_TOPOLOGY_KEY`` env var (set by the host framework, e.g. athena)
+    2. ``ws{world_size}`` when torch.distributed is initialized
+    3. ``ws1`` (single-process default)
     """
+    topo = os.environ.get("MAGI_COMPILE_TOPOLOGY_KEY")
+    if topo:
+        return topo
     if not torch.distributed.is_initialized():
         return "ws1"
-    try:
-        from athena.distributed import psm
-
-        if psm.is_initialized():
-            return psm.topology_key()
-    except (ImportError, AttributeError, RuntimeError):
-        pass
     return f"ws{torch.distributed.get_world_size()}"
 
 

--- a/magi_compiler/config.py
+++ b/magi_compiler/config.py
@@ -384,20 +384,37 @@ class CompileConfig(BaseSettings):
         return self.__str__(indent=indent)
 
 
-def model_rank_dir_name(model_idx: int, model_tag: str | None) -> str:
-    """Directory name for a model instance: ``model_{idx}[_{tag}]_rank_{rank}_ws{world_size}``.
+def _get_parallel_topology() -> str:
+    """Return a compact topology string for compile-cache keying.
 
-    world_size is included because runtime model behavior (e.g. MoE EP head
-    padding, tensor strides in custom-op meta functions) can differ across
-    world sizes.  Without it, switching between e.g. EP=6 and EP=8 would
-    silently reuse stale compiled artifacts and trigger stride-mismatch
-    assertions at runtime.
+    Delegates to PSM.topology_key() which encodes all leaf parallel dimensions
+    (tp, cp, ep, dp, pp, etc.) -- different topologies produce different tensor
+    strides in custom-op meta functions and must not share cached artifacts.
+    """
+    if not torch.distributed.is_initialized():
+        return "ws1"
+    try:
+        from athena.distributed import psm
+
+        if psm.is_initialized():
+            return psm.topology_key()
+    except (ImportError, AttributeError, RuntimeError):
+        pass
+    return f"ws{torch.distributed.get_world_size()}"
+
+
+def model_rank_dir_name(model_idx: int, model_tag: str | None) -> str:
+    """Directory name: ``model_{idx}[_{tag}]_rank_{rank}_{topology}``.
+
+    Topology encodes all parallel dimension sizes via PSM.topology_key().
+    Different topologies produce different tensor strides in custom-op meta
+    functions; without isolation, stale artifacts trigger stride-mismatch assertions.
     """
     rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
-    world_size = torch.distributed.get_world_size() if torch.distributed.is_initialized() else 1
+    topo = _get_parallel_topology()
     if model_tag:
-        return f"model_{model_idx}_{model_tag}_rank_{rank}_ws{world_size}"
-    return f"model_{model_idx}_rank_{rank}_ws{world_size}"
+        return f"model_{model_idx}_{model_tag}_rank_{rank}_{topo}"
+    return f"model_{model_idx}_rank_{rank}_{topo}"
 
 
 def debug_dump_path(cache_root_dir: str, model_idx: int, model_tag: str | None = None) -> Path:

--- a/magi_compiler/config.py
+++ b/magi_compiler/config.py
@@ -385,11 +385,19 @@ class CompileConfig(BaseSettings):
 
 
 def model_rank_dir_name(model_idx: int, model_tag: str | None) -> str:
-    """Directory name for a model instance: ``model_{idx}[_{tag}]_rank_{rank}``."""
+    """Directory name for a model instance: ``model_{idx}[_{tag}]_rank_{rank}_ws{world_size}``.
+
+    world_size is included because runtime model behavior (e.g. MoE EP head
+    padding, tensor strides in custom-op meta functions) can differ across
+    world sizes.  Without it, switching between e.g. EP=6 and EP=8 would
+    silently reuse stale compiled artifacts and trigger stride-mismatch
+    assertions at runtime.
+    """
     rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+    world_size = torch.distributed.get_world_size() if torch.distributed.is_initialized() else 1
     if model_tag:
-        return f"model_{model_idx}_{model_tag}_rank_{rank}"
-    return f"model_{model_idx}_rank_{rank}"
+        return f"model_{model_idx}_{model_tag}_rank_{rank}_ws{world_size}"
+    return f"model_{model_idx}_rank_{rank}_ws{world_size}"
 
 
 def debug_dump_path(cache_root_dir: str, model_idx: int, model_tag: str | None = None) -> Path:

--- a/magi_compiler/magi_backend/magi_backend.py
+++ b/magi_compiler/magi_backend/magi_backend.py
@@ -129,6 +129,7 @@ class CompilerManager:
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         magi_logger.info("Using cache directory: %s for MagiCompiler", cache_dir)
         self.cache = {}
+        self._remaining_restart_skips = {}
 
         if self.cache_file_path.exists():
             with self.cache_file_path.open() as f:

--- a/magi_compiler/magi_backend/magi_backend.py
+++ b/magi_compiler/magi_backend/magi_backend.py
@@ -128,12 +128,11 @@ class CompilerManager:
 
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         magi_logger.info("Using cache directory: %s for MagiCompiler", cache_dir)
+        self.cache = {}
+
         if self.cache_file_path.exists():
-            # load the cache from the file
             with self.cache_file_path.open() as f:
-                # Parse Python literals using ast.literal_eval, which is a safe alternative to eval().
                 raw = ast.literal_eval(f.read())
-                self.cache = {}
                 for entry, handle in raw.items():
                     cache_entry = CacheEntry(*entry)
                     cache_handle = CacheHandle(*handle)
@@ -160,6 +159,13 @@ class CompilerManager:
             return None
 
         cache_handle = self.cache[cache_entry]
+
+        artifact_dir = Path(cache_handle.path)
+        if not artifact_dir.exists():
+            magi_logger.warning("Stale cache entry removed (artifact dir missing): %s", cache_handle.path)
+            del self.cache[cache_entry]
+            return None
+
         if cache_entry.graph_index not in self._remaining_restart_skips:
             self._remaining_restart_skips[cache_entry.graph_index] = cache_handle.restart_analysis_count
         remaining = self._remaining_restart_skips[cache_entry.graph_index]
@@ -224,6 +230,7 @@ class CompilerManager:
         if self.disable_cache:
             return False
         if cache_handle is None:
+            self.cache.pop(cache_entry, None)
             return False
 
         prev_handle = self.cache.get(cache_entry)

--- a/magi_compiler/magi_backend/magi_backend.py
+++ b/magi_compiler/magi_backend/magi_backend.py
@@ -129,7 +129,6 @@ class CompilerManager:
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         magi_logger.info("Using cache directory: %s for MagiCompiler", cache_dir)
         self.cache = {}
-        self._remaining_restart_skips = {}
 
         if self.cache_file_path.exists():
             # load the cache from the file
@@ -140,6 +139,10 @@ class CompilerManager:
                     cache_entry = CacheEntry(*entry)
                     cache_handle = CacheHandle(*handle)
                     self.cache[cache_entry] = cache_handle
+        else:
+            # No persisted cache on disk -- clear any ghost restart-skip state
+            # left by a prior (incomplete) compilation in the same process.
+            self._remaining_restart_skips = {}
 
         self.compiler.initialize_cache(cache_dir=self.cache_dir)
 

--- a/magi_compiler/magi_backend/magi_backend.py
+++ b/magi_compiler/magi_backend/magi_backend.py
@@ -132,7 +132,9 @@ class CompilerManager:
         self._remaining_restart_skips = {}
 
         if self.cache_file_path.exists():
+            # load the cache from the file
             with self.cache_file_path.open() as f:
+                # Parse Python literals using ast.literal_eval, which is a safe alternative to eval().
                 raw = ast.literal_eval(f.read())
                 for entry, handle in raw.items():
                     cache_entry = CacheEntry(*entry)

--- a/tests/feature_tests/test_cache_invariant.py
+++ b/tests/feature_tests/test_cache_invariant.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026 SandAI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cache invariant tests: every entry in ``CompilerManager.cache`` must have a
+valid on-disk artifact directory.  These tests reproduce three classes of stale-
+cache bugs present on ``origin/main`` (before fix).
+
+Each test constructs a ``CompilerManager`` with known-bad state and asserts the
+invariant that the code *should* maintain.  On unfixed code they FAIL.
+"""
+
+from __future__ import annotations
+
+import pprint
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.fx as fx
+
+from magi_compiler.config import CompileConfig
+from magi_compiler.magi_backend._cache_data_cls import CacheEntry, CacheHandle
+from magi_compiler.magi_backend.magi_backend import CompilerManager
+
+
+@pytest.fixture(autouse=True)
+def cleanup_cache():
+    """Override the global autouse cleanup_cache fixture from conftest.py.
+
+    These tests use tmp_path and don't need global cache cleanup, which can
+    hang when cache_root_dir points to a large or network-mounted directory.
+    """
+    yield
+
+
+def _make_cm(tmp_path: Path) -> CompilerManager:
+    saved_argv = sys.argv
+    try:
+        sys.argv = ["test"]
+        cfg = CompileConfig(cache_root_dir=str(tmp_path), backend="eager")
+    finally:
+        sys.argv = saved_argv
+    return CompilerManager(cfg)
+
+
+def _write_index(cache_dir: Path, data: dict) -> None:
+    (cache_dir / "subgraph_indices.py").write_text(pprint.pformat(data))
+
+
+def _dummy_graph() -> fx.GraphModule:
+    return fx.GraphModule(torch.nn.Module(), fx.Graph())
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: load() does not check whether artifact dir exists on disk.
+#
+# On origin/main, load() blindly passes the handle to compiler.load() which
+# calls CompiledArtifact.load() on a non-existent path → crash.
+#
+# Expected after fix: load() returns None and removes the stale entry.
+# ---------------------------------------------------------------------------
+
+
+def test_load_rejects_missing_artifact_dir(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "model_bug1"
+    cache_dir.mkdir(parents=True)
+    bogus = cache_dir / "artifact_shape_None_subgraph_0"
+    assert not bogus.exists()
+
+    data = {(None, 0, "inductor_standalone"): ("artifact_shape_None_subgraph_0", str(bogus), 0)}
+    _write_index(cache_dir, data)
+
+    cm = _make_cm(tmp_path)
+    cm.initialize_cache(cache_dir)
+
+    entry = CacheEntry(None, 0, "inductor_standalone")
+    assert entry in cm.cache, "precondition: entry loaded from index"
+
+    # Patch compiler.load so that if CompilerManager.load reaches it we know
+    # the guard is missing (it should never be called for a missing dir).
+    with patch.object(cm.compiler, "load", side_effect=AssertionError("compiler.load should not be called")):
+        result = cm.load(_dummy_graph(), [], entry)
+
+    assert result is None, "load() must return None for missing artifact dir"
+    assert entry not in cm.cache, "stale entry must be removed from cache"
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: _maybe_store_cache_entry(entry, None, ...) does not remove a stale
+# handle that was rehydrated from subgraph_indices.py.
+#
+# On origin/main, it just returns False; the ghost handle survives in memory
+# and save_to_file() will re-serialize it.
+#
+# Expected after fix: the stale entry is deleted from self.cache.
+# ---------------------------------------------------------------------------
+
+
+def test_store_none_handle_removes_stale_entry(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "model_bug2"
+    cache_dir.mkdir(parents=True)
+    bogus = cache_dir / "artifact_shape_None_subgraph_0"
+
+    data = {(None, 0, "inductor_standalone"): ("artifact_shape_None_subgraph_0", str(bogus), 1)}
+    _write_index(cache_dir, data)
+
+    cm = _make_cm(tmp_path)
+    cm.initialize_cache(cache_dir)
+
+    entry = CacheEntry(None, 0, "inductor_standalone")
+    assert entry in cm.cache, "precondition: entry loaded from index"
+
+    cm._maybe_store_cache_entry(entry, None, None, "artifact_shape_None_subgraph_0")
+
+    assert entry not in cm.cache, "stale entry must be removed when handle is None"
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: initialize_cache() does not reset self.cache when
+# subgraph_indices.py is absent.
+#
+# On origin/main, `self.cache = {}` only runs inside the
+# `if self.cache_file_path.exists()` branch.  So a second call to
+# initialize_cache (same dir, no index file) preserves ghost handles
+# injected between the two calls.
+#
+# Expected after fix: self.cache is always reset to {}.
+# Note: _remaining_restart_skips is NOT reset by initialize_cache because
+# it is runtime consumption state that must survive across Dynamo
+# RestartAnalysis retries (which re-call initialize_cache).
+# ---------------------------------------------------------------------------
+
+
+def test_reinit_without_indices_clears_memory(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "model_bug3"
+    cache_dir.mkdir(parents=True)
+
+    cm = _make_cm(tmp_path)
+    cm.initialize_cache(cache_dir)
+
+    # Simulate a ghost handle left from a partial first compilation.
+    bogus = cache_dir / "artifact_shape_None_subgraph_0"
+    entry = CacheEntry(None, 0, "inductor_standalone")
+    cm.cache[entry] = CacheHandle("artifact_shape_None_subgraph_0", str(bogus), 1)
+    cm._remaining_restart_skips[0] = 1
+
+    assert not (cache_dir / "subgraph_indices.py").exists(), "precondition: no index file"
+
+    # Re-initialize same directory — should clear cache dict.
+    cm.initialize_cache(cache_dir)
+
+    assert entry not in cm.cache, "ghost handle must be cleared on re-init"

--- a/tests/feature_tests/test_cache_invariant.py
+++ b/tests/feature_tests/test_cache_invariant.py
@@ -23,11 +23,9 @@ invariant that the code *should* maintain.  On unfixed code they FAIL.
 from __future__ import annotations
 
 import pprint
-import sys
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 import torch
 import torch.fx as fx
 
@@ -36,23 +34,8 @@ from magi_compiler.magi_backend._cache_data_cls import CacheEntry, CacheHandle
 from magi_compiler.magi_backend.magi_backend import CompilerManager
 
 
-@pytest.fixture(autouse=True)
-def cleanup_cache():
-    """Override the global autouse cleanup_cache fixture from conftest.py.
-
-    These tests use tmp_path and don't need global cache cleanup, which can
-    hang when cache_root_dir points to a large or network-mounted directory.
-    """
-    yield
-
-
 def _make_cm(tmp_path: Path) -> CompilerManager:
-    saved_argv = sys.argv
-    try:
-        sys.argv = ["test"]
-        cfg = CompileConfig(cache_root_dir=str(tmp_path), backend="eager")
-    finally:
-        sys.argv = saved_argv
+    cfg = CompileConfig(cache_root_dir=str(tmp_path), backend="eager", _cli_parse_args=False)
     return CompilerManager(cfg)
 
 
@@ -138,9 +121,6 @@ def test_store_none_handle_removes_stale_entry(tmp_path: Path) -> None:
 # injected between the two calls.
 #
 # Expected after fix: self.cache is always reset to {}.
-# Note: _remaining_restart_skips is NOT reset by initialize_cache because
-# it is runtime consumption state that must survive across Dynamo
-# RestartAnalysis retries (which re-call initialize_cache).
 # ---------------------------------------------------------------------------
 
 
@@ -159,7 +139,8 @@ def test_reinit_without_indices_clears_memory(tmp_path: Path) -> None:
 
     assert not (cache_dir / "subgraph_indices.py").exists(), "precondition: no index file"
 
-    # Re-initialize same directory — should clear cache dict.
+    # Re-initialize same directory — should clear everything.
     cm.initialize_cache(cache_dir)
 
     assert entry not in cm.cache, "ghost handle must be cleared on re-init"
+    assert 0 not in cm._remaining_restart_skips, "restart skips must be cleared when no index"

--- a/tests/feature_tests/test_cache_topology_isolation.py
+++ b/tests/feature_tests/test_cache_topology_isolation.py
@@ -65,14 +65,27 @@ class TestTopologyCacheIsolation:
             topo = _get_parallel_topology()
         assert topo == "ws1"
 
-    def test_dist_without_psm_uses_world_size(self):
-        """With dist but no PSM, falls back to ws{world_size}."""
+    def test_dist_without_env_uses_world_size(self):
+        """With dist but no MAGI_COMPILE_TOPOLOGY_KEY, falls back to ws{world_size}."""
         p1, p2, p3 = _patch_dist(is_init=True, rank=0, world_size=8)
-        with p1, p2, p3, patch.dict("sys.modules", {"athena": None, "athena.distributed": None}):
+        with p1, p2, p3, patch.dict("os.environ", {}, clear=False):
+            # Ensure env var is NOT set
+            import os
+
+            os.environ.pop("MAGI_COMPILE_TOPOLOGY_KEY", None)
             topo = _get_parallel_topology()
             name = model_rank_dir_name(0, None)
         assert topo == "ws8"
         assert "ws8" in name
+
+    def test_env_var_takes_priority(self):
+        """MAGI_COMPILE_TOPOLOGY_KEY env var overrides all other resolution."""
+        p1, p2, p3 = _patch_dist(is_init=True, rank=0, world_size=8)
+        with p1, p2, p3, patch.dict("os.environ", {"MAGI_COMPILE_TOPOLOGY_KEY": "ep6_cp2_dp1"}):
+            topo = _get_parallel_topology()
+            name = model_rank_dir_name(0, None)
+        assert topo == "ep6_cp2_dp1"
+        assert "ep6_cp2_dp1" in name
 
     def test_same_topology_same_path(self):
         p1, p2, p3 = _patch_dist(is_init=False)

--- a/tests/feature_tests/test_cache_topology_isolation.py
+++ b/tests/feature_tests/test_cache_topology_isolation.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026 SandAI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Verify that different parallel topologies produce isolated cache directories,
+preventing EP/CP cross-contamination of compiled artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+
+from magi_compiler.config import _get_parallel_topology, magi_cache_dump_path, model_rank_dir_name
+
+
+def _patch_dist(is_init=False, rank=0, world_size=1):
+    """Context manager to mock torch.distributed state."""
+    return (
+        patch.object(torch.distributed, "is_initialized", return_value=is_init),
+        patch.object(torch.distributed, "get_rank", return_value=rank),
+        patch.object(torch.distributed, "get_world_size", return_value=world_size),
+    )
+
+
+class TestTopologyCacheIsolation:
+    """Different topologies must map to different cache directory paths."""
+
+    def test_model_rank_dir_includes_topology(self):
+        p1, p2, p3 = _patch_dist(is_init=False)
+        with p1, p2, p3:
+            with patch("magi_compiler.config._get_parallel_topology", return_value="ep6_cp1"):
+                name_a = model_rank_dir_name(0, None)
+            with patch("magi_compiler.config._get_parallel_topology", return_value="ep8_cp1"):
+                name_b = model_rank_dir_name(0, None)
+        assert name_a != name_b
+        assert "ep6_cp1" in name_a
+        assert "ep8_cp1" in name_b
+
+    def test_model_rank_dir_with_tag(self):
+        p1, p2, p3 = _patch_dist(is_init=False)
+        with p1, p2, p3:
+            with patch("magi_compiler.config._get_parallel_topology", return_value="ws4"):
+                name = model_rank_dir_name(1, "sr")
+        assert "model_1_sr_rank_" in name
+        assert "ws4" in name
+
+    def test_magi_cache_dump_path_varies_with_topology(self, tmp_path: Path):
+        p1, p2, p3 = _patch_dist(is_init=False)
+        with p1, p2, p3:
+            with patch("magi_compiler.config._get_parallel_topology", return_value="ep6_cp1"):
+                path_a = magi_cache_dump_path(str(tmp_path), 0)
+            with patch("magi_compiler.config._get_parallel_topology", return_value="ep8_cp1"):
+                path_b = magi_cache_dump_path(str(tmp_path), 0)
+        assert path_a != path_b
+        assert path_a.parent == path_b.parent
+        assert "ep6_cp1" in str(path_a)
+        assert "ep8_cp1" in str(path_b)
+
+    def test_no_dist_defaults_to_ws1(self):
+        p1, p2, p3 = _patch_dist(is_init=False)
+        with p1, p2, p3:
+            topo = _get_parallel_topology()
+        assert topo == "ws1"
+
+    def test_dist_without_psm_uses_world_size(self):
+        """With dist but no PSM, falls back to ws{world_size}."""
+        p1, p2, p3 = _patch_dist(is_init=True, rank=0, world_size=8)
+        with p1, p2, p3, patch.dict("sys.modules", {"athena": None, "athena.distributed": None}):
+            topo = _get_parallel_topology()
+            name = model_rank_dir_name(0, None)
+        assert topo == "ws8"
+        assert "ws8" in name
+
+    def test_same_topology_same_path(self):
+        p1, p2, p3 = _patch_dist(is_init=False)
+        with p1, p2, p3:
+            with patch("magi_compiler.config._get_parallel_topology", return_value="ep6_cp2"):
+                name1 = model_rank_dir_name(0, None)
+                name2 = model_rank_dir_name(0, None)
+        assert name1 == name2


### PR DESCRIPTION
## 动机

切换 EP 配置（如 adaptive DP 从 EP=6 切到 EP=8）后，不同拓扑下 MoE head padding 产生的 tensor stride 不同，但旧 cache key **不含并行拓扑信息**，rank 0 的编译产物被错误复用，运行时 `assert_size_stride` 崩溃。

## 改动要点

1. **cache 目录追加 topology 后缀**：`model_rank_dir_name()` 从 `model_{idx}_rank_{rank}` 改为 `model_{idx}_rank_{rank}_{topology}`。topology 通过 `MAGI_COMPILE_TOPOLOGY_KEY` 环境变量注入（由上层框架设置），未设置时回退到 `ws{world_size}`，单卡等价 `_ws1`。MagiCompiler 保持独立，无反向依赖。
2. **CompilerManager cache 健壮性增强**：
   - `load()` 增加 `artifact_dir.exists()` 守卫——磁盘产物缺失时清理幽灵 entry 而非崩溃
   - `_maybe_store_cache_entry(None)` 时移除 stale entry，防止 `save_to_file()` 序列化脏数据
   - `initialize_cache()` 无 index 文件时清理 ghost `_remaining_restart_skips`，有 index 文件时保留（兼容 dynamo RestartAnalysis 重试流程）
3. **新增 10 个回归测试**（无 GPU 依赖，纯逻辑）：
   - `test_cache_invariant.py`（3 个）：artifact 缺失防御、stale entry 清理、re-init 幽灵状态清理
   - `test_cache_topology_isolation.py`（7 个）：不同拓扑不同路径、env var 优先级、world_size 回退、同拓扑稳定性

## 兼容性

- 单卡/非分布式场景：路径仅多 `_ws1` 后缀，功能无影响
- 现有 cache 首次升级后 miss 一次重编译（路径变化），后续正常命中
- 上层框架只需在编译前 `export MAGI_COMPILE_TOPOLOGY_KEY=$(psm.topology_key())` 即可启用精确隔离