### PR TITLE
[Feat] Add FoldPythonScalarConstantsPass to fold pure Python scalar nodes before piecewise split

### DIFF
--- a/magi_compiler/passes/full_graph/fold_python_scalar_constants.py
+++ b/magi_compiler/passes/full_graph/fold_python_scalar_constants.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 SandAI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fold pure Python scalar expressions before piecewise graph splitting."""
+
+import operator
+from typing import Any
+
+import torch
+from torch.utils._pytree import tree_map
+
+from ...magi_depyf.timeline import emit_pass_lifecycle
+from ..pass_base import MagiInductorPass
+
+
+class FoldPythonScalarConstantsPass(MagiInductorPass):
+    """Replace allowlisted constant-only scalar FX nodes with Python literals.
+
+    Dynamo may recapture a tensor-derived ``SymFloat`` as a Python constant but
+    retain scalar arithmetic such as ``operator.neg(448.0)`` as an FX node.  If
+    that value is reused after a piecewise boundary, ``split_module`` promotes
+    the node to a subgraph output.  Inductor does not accept a bare Python float
+    as a compiled graph output.
+
+    Only explicitly allowlisted pure operators are evaluated, and every input
+    must already be a plain Python scalar.  Tensor and symbolic values are never
+    folded.
+    """
+
+    _SCALAR_TYPES = (bool, int, float, complex)
+    _PURE_SCALAR_OPS = {
+        operator.abs,
+        operator.add,
+        operator.floordiv,
+        operator.mod,
+        operator.mul,
+        operator.neg,
+        operator.pos,
+        operator.pow,
+        operator.sub,
+        operator.truediv,
+    }
+
+    def is_applicable(self, graph: torch.fx.Graph, shape: int | None = None) -> bool:
+        return any(node.op == "call_function" and node.target in self._PURE_SCALAR_OPS for node in graph.nodes)
+
+    @classmethod
+    def _is_plain_scalar_tree(cls, value: Any) -> bool:
+        if isinstance(value, cls._SCALAR_TYPES):
+            return True
+        if isinstance(value, (tuple, list)):
+            return all(cls._is_plain_scalar_tree(item) for item in value)
+        if isinstance(value, dict):
+            return all(isinstance(key, str) and cls._is_plain_scalar_tree(item) for key, item in value.items())
+        return False
+
+    @emit_pass_lifecycle
+    def __call__(self, graph: torch.fx.Graph) -> None:
+        folded_values: dict[torch.fx.Node, bool | int | float | complex] = {}
+
+        def replace_folded(value: Any) -> Any:
+            if isinstance(value, torch.fx.Node):
+                return folded_values.get(value, value)
+            return value
+
+        for node in list(graph.nodes):
+            if node.op != "call_function" or node.target not in self._PURE_SCALAR_OPS:
+                continue
+
+            args = tree_map(replace_folded, node.args)
+            kwargs = tree_map(replace_folded, node.kwargs)
+            if not self._is_plain_scalar_tree(args) or not self._is_plain_scalar_tree(kwargs):
+                continue
+
+            try:
+                result = node.target(*args, **kwargs)
+            except (ArithmeticError, TypeError, ValueError):
+                continue
+            if not isinstance(result, self._SCALAR_TYPES):
+                continue
+
+            folded_values[node] = result
+
+        if not folded_values:
+            return
+
+        for node in graph.nodes:
+            node.args = tree_map(replace_folded, node.args)
+            node.kwargs = tree_map(replace_folded, node.kwargs)
+
+        graph.eliminate_dead_code()
+        graph.lint()

--- a/magi_compiler/passes/full_graph/full_graph_pass_mgr.py
+++ b/magi_compiler/passes/full_graph/full_graph_pass_mgr.py
@@ -15,6 +15,7 @@
 import torch
 
 from ...magi_depyf.timeline import observe_lifecycle
+from .fold_python_scalar_constants import FoldPythonScalarConstantsPass
 from .remove_item import RemoveItemPass
 from .remove_useless_ops import EliminateIdentityViewCastPass
 from .replace_sage_atten import ReplaceSageAttentionPass
@@ -31,6 +32,7 @@ class FullGraphPassManager:
         if self.pass_config.enable_sage_attn:
             self.passes.append(ReplaceSageAttentionPass())
         self.passes.append(RemoveItemPass())
+        self.passes.append(FoldPythonScalarConstantsPass())
         self.passes.append(EliminateIdentityViewCastPass())
 
     @observe_lifecycle("full_graph_manager")

--- a/tests/feature_tests/test_python_scalar_constant_folding.py
+++ b/tests/feature_tests/test_python_scalar_constant_folding.py
@@ -91,11 +91,6 @@ def _boundary(x: torch.Tensor) -> torch.Tensor:
 
 class _NegatedConstantAcrossBoundaryBlock(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # Mirrors the FP8 quant clamp: ``clamp(x, -448.0, 448.0)`` reused on both
-        # sides of a piecewise boundary.  Dynamo may recapture ``-448.0`` as an
-        # ``operator.neg(448.0)`` node; without constant folding this node is
-        # promoted to a subgraph output by ``split_module`` and Inductor rejects
-        # the bare Python float output.
         x = x.float().clamp(-_FP8_MAX_VALUE, _FP8_MAX_VALUE)
         x = _boundary(x)
         return x.float().clamp(-_FP8_MAX_VALUE, _FP8_MAX_VALUE)

--- a/tests/feature_tests/test_python_scalar_constant_folding.py
+++ b/tests/feature_tests/test_python_scalar_constant_folding.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026 SandAI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for folding constant Python scalar nodes before graph splitting."""
+
+import operator
+import tempfile
+
+import pytest
+import torch
+import torch.nn as nn
+
+from magi_compiler import magi_compile, magi_register_custom_op
+from magi_compiler.config import CompileMode, get_compile_config
+from magi_compiler.magi_backend import magi_backend as magi_backend_module
+from magi_compiler.passes.full_graph.fold_python_scalar_constants import FoldPythonScalarConstantsPass
+
+_FP8_MAX_VALUE = 448.0
+
+
+def _output_values(graph: torch.fx.Graph) -> tuple:
+    output = next(node for node in graph.nodes if node.op == "output")
+    assert isinstance(output.args[0], tuple)
+    return output.args[0]
+
+
+def test_folds_constant_scalar_expression_chain_to_literals():
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    neg = graph.call_function(operator.neg, (448.0,))
+    low = graph.call_function(operator.sub, (neg, 1.0))
+    graph.output((x, neg, low))
+
+    fold = FoldPythonScalarConstantsPass()
+    assert fold.is_applicable(graph)
+    fold(graph)
+
+    assert _output_values(graph) == (x, -448.0, -449.0)
+    assert not any(node.op == "call_function" and node.target in {operator.neg, operator.sub} for node in graph.nodes)
+
+
+def test_does_not_fold_tensor_or_symbolic_dependent_expression():
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+    neg = graph.call_function(operator.neg, (x,))
+    graph.output((neg,))
+
+    FoldPythonScalarConstantsPass()(graph)
+
+    assert _output_values(graph) == (neg,)
+    assert neg in graph.nodes
+
+
+def test_does_not_execute_unlisted_call_function():
+    called = False
+
+    def unlisted(value):
+        nonlocal called
+        called = True
+        return -value
+
+    graph = torch.fx.Graph()
+    custom = graph.call_function(unlisted, (448.0,))
+    graph.output((custom,))
+
+    FoldPythonScalarConstantsPass()(graph)
+
+    assert not called
+    assert _output_values(graph) == (custom,)
+
+
+def _boundary_meta(x: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(x)
+
+
+@magi_register_custom_op("test_scalar_fold::boundary", infer_output_meta_fn=_boundary_meta, is_subgraph_boundary=True)
+def _boundary(x: torch.Tensor) -> torch.Tensor:
+    return x + 1.0
+
+
+class _NegatedConstantAcrossBoundaryBlock(nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Mirrors the FP8 quant clamp: ``clamp(x, -448.0, 448.0)`` reused on both
+        # sides of a piecewise boundary.  Dynamo may recapture ``-448.0`` as an
+        # ``operator.neg(448.0)`` node; without constant folding this node is
+        # promoted to a subgraph output by ``split_module`` and Inductor rejects
+        # the bare Python float output.
+        x = x.float().clamp(-_FP8_MAX_VALUE, _FP8_MAX_VALUE)
+        x = _boundary(x)
+        return x.float().clamp(-_FP8_MAX_VALUE, _FP8_MAX_VALUE)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_recaptured_negated_float_constant_is_folded_before_split(monkeypatch):
+    torch._dynamo.reset()
+    config = get_compile_config()
+    monkeypatch.setattr(config, "compile_mode", CompileMode.MAGI_COMPILE)
+    monkeypatch.setattr(config, "backend", "inductor")
+    monkeypatch.setattr(config, "cache_root_dir", tempfile.mkdtemp())
+
+    split_calls: list[torch.fx.GraphModule] = []
+    original_split = magi_backend_module.MagiBackend._split_graph
+
+    def capture_split(self, graph):
+        split_calls.append(graph)
+        return original_split(self, graph)
+
+    monkeypatch.setattr(magi_backend_module.MagiBackend, "_split_graph", capture_split)
+
+    model = magi_compile(_NegatedConstantAcrossBoundaryBlock().cuda().eval(), dynamic_arg_dims={"x": 0})
+    # A value above the FP8 max so clamping is observable in the output.
+    x = torch.full((8, 16), 1000.0, device="cuda")
+    with torch.no_grad():
+        output = model(x).cpu()
+
+    # boundary adds 1.0 to the clamped 448.0, and the second clamp caps it back.
+    torch.testing.assert_close(output, torch.full_like(output, _FP8_MAX_VALUE))
+
+    assert split_calls
+    for full_graph in split_calls:
+        assert not any(
+            node.op == "call_function"
+            and node.target is operator.neg
+            and all(not isinstance(arg, torch.fx.Node) for arg in node.args)
+            for node in full_graph.graph.nodes
+        )


### PR DESCRIPTION
## What

Add `FoldPythonScalarConstantsPass` to the full-graph pass pipeline (runs before `split_module`). It evaluates an allowlist of pure scalar operators whose inputs are already plain Python scalars, replaces the FX node with the resulting literal, and removes the now-dead node.

## Why

After a `TensorifyScalarRestartAnalysis` recapture, a tensor-derived `SymFloat` (e.g. the FP8 clamp bound `-448.0`) can come back as a concrete Python constant while the scalar arithmetic stays as an FX node (`operator.neg(448.0)`). When that value is reused across a piecewise boundary, `split_module` promotes the node to a subgraph output — and Inductor rejects a bare Python float as a compiled-graph output, crashing compilation.

**torch has no native pass that folds Python-scalar FX nodes into literals.** 
- `torch._inductor.constant_folding` only folds *tensor* constants (it explicitly skips nodes with no tensor input, and materializes results as `get_attr` buffers), and it runs *inside* each subgraph *after* `split_module` — too late for our case.
 - `torch.fx.experimental.const_fold.split_const_subgraphs` restructures the graph via its own `split_module`, conflicting with our piecewise splitting. So this small, pre-split scalar-literal fold fills a real gap rather than duplicating existing functionality.

## Scope / Safety

- Only an allowlist of pure scalar operators is evaluated.
- Folds only when **all** inputs are already plain Python scalars; Tensor / SymInt / SymFloat / runtime-dependent values are never touched.
- Arithmetic errors are caught and skipped; runs unconditionally on every (re)capture, so it also handles graphs that no longer contain `item()`.

## Tests

- Unit tests: constant-chain folding, no-op on tensor/symbolic inputs, and no execution of non-allowlisted call_functions.
- End-to-end regression reproducing the FP8 clamp-across-boundary crash.