### PR TITLE
[Fix] Key compiled artifacts by the sizes they were specialised on

### DIFF
--- a/magi_compiler/magi_backend/_cache_data_cls.py
+++ b/magi_compiler/magi_backend/_cache_data_cls.py
@@ -27,3 +27,9 @@ class CacheEntry:
     runtime_shape: int | None
     graph_index: int
     backend_name: str
+    # A digest of the sizes dynamo turned into constants for this trace. runtime_shape
+    # alone does not identify an artifact: it is None for every dynamically compiled
+    # graph, while the dimensions nobody marked dynamic are baked in and differ between
+    # traces. Without this, a graph traced for one input size is silently handed to
+    # another and fails inside the kernel on a stride assertion.
+    static_sizes: str = ""

--- a/magi_compiler/magi_backend/magi_backend.py
+++ b/magi_compiler/magi_backend/magi_backend.py
@@ -16,7 +16,7 @@ import ast
 import dataclasses
 import pprint
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -73,6 +73,21 @@ def make_compiler(compile_config: CompileConfig) -> CompilerInterface:
         assert compile_config.backend == "eager", f"Invalid backend for MagiCompiler: {compile_config.backend}"
         magi_logger.info("Using EagerAdaptor")
         return EagerAdaptor()
+
+
+def _static_sizes_digest(example_inputs: Iterable[Any]) -> str:
+    """The sizes this trace was specialised on.
+
+    A dimension marked dynamic arrives as a SymInt and the artifact generalises over it.
+    Every other dimension is a plain int that is now a constant in the graph, so two
+    traces that differ only in those ints are different programs.
+    """
+    sizes = [
+        (i, tuple(d for d in x.shape if isinstance(d, int)))
+        for i, x in enumerate(example_inputs)
+        if isinstance(x, torch.Tensor)
+    ]
+    return compute_hash([sizes])[:10]
 
 
 class CompilerManager:
@@ -151,7 +166,7 @@ class CompilerManager:
             return
         # serialize to a literal-friendly dict
         serializable = {
-            (e.runtime_shape, e.graph_index, e.backend_name): (h.key, h.path, h.restart_analysis_count)
+            (e.runtime_shape, e.graph_index, e.backend_name, e.static_sizes): (h.key, h.path, h.restart_analysis_count)
             for e, h in self.cache.items()
         }
         printer = pprint.PrettyPrinter(indent=4)
@@ -209,13 +224,14 @@ class CompilerManager:
             compilation_start_time = time.time()
 
         # Step1: Try loading from the cache
-        cache_entry = CacheEntry(runtime_shape, graph_index, self.compiler.name)
+        static_sizes = _static_sizes_digest(example_inputs)
+        cache_entry = CacheEntry(runtime_shape, graph_index, self.compiler.name, static_sizes)
         compiled_graph = self.load(graph, example_inputs, cache_entry)
         if compiled_graph is not None:
             return compiled_graph
 
         # Step2: Compile the graph
-        key = f"artifact_shape_{runtime_shape}_subgraph_{graph_index}"
+        key = f"artifact_shape_{runtime_shape}_static_{static_sizes}_subgraph_{graph_index}"
 
         with self.compile_context(runtime_shape, graph_index):
             compiled_graph, cache_handle = self.compiler.compile(


### PR DESCRIPTION
Stacked on #49.

## Problem

An artifact is keyed by `runtime_shape` alone, which is `None` for every dynamically compiled graph. But the dimensions nobody marked dynamic are not dynamic: `_mark_static_shapes` burns them into the graph as constants. So a graph traced for one input size is silently handed to another, and the mismatch surfaces far from its cause, as a stride assertion inside the generated kernel:

```
AssertionError: expected size 75==7, stride 8160==8160 at dim=2
This error most often comes from a incorrect fake (aka meta) kernel for a custom op.
  File ".cache/magi_compiler/magi_cache/model_1_decode_rank_0_cp1_dp1_pp1_tp1/5a9aca216c/artifact_shape_None_subgraph_0/...", line 6779, in call
```

A VAE decode graph traced for a 1s video clip (7 latent frames) was loaded for a 12s one (75 frames): both resolve to `artifact_shape_None_subgraph_0` under the same model tag. The graph signature confirms only two dims generalise — `submod_0(..., l_z_, s37, s38, ...)` — the declared `dynamic_arg_dims={"z": [3, 4]}`, while dim 2 is a constant.

Nothing reports a miss; the load succeeds and the failure looks like a bad meta kernel.

## Fix

`CacheEntry` and the artifact path now carry a digest of the sizes that were specialised. Traces differing only in those sizes stop colliding: the second one misses, compiles, and stores under its own key. Dimensions marked dynamic arrive as `SymInt` and are excluded from the digest, so genuinely shape-agnostic artifacts are reused exactly as before, and no extra compilation is introduced — dynamo already retraces on those shape changes, this only stops the disk cache from serving the wrong result across processes.

## Verification

```
1s : 89e2381f22
12s: f8a6bb7f7a
1s again: 89e2381f22
```

End to end on athena's gaga4 pipeline: the 12s clip that reproduced the assertion above now decodes through, 8 requests at 73s each.

Same class of defect as #42 (parallel topology into the cache directory) and #49 (compile state per topology): a key that omits something the artifact actually depends on.