### PR TITLE
[Fix] fsdp_overlap symbol-name rank divergence + drop pinned example_inputs in MagiSerializableFunction

### DIFF
--- a/magi_compiler/magi_backend/compile_artifacts.py
+++ b/magi_compiler/magi_backend/compile_artifacts.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import torch
-from torch.utils._pytree import tree_map_only
 
 from magi_compiler.utils import magi_logger
 
@@ -48,13 +47,18 @@ class MagiSerializableFunction(SerializableCallable):
     disk. There's no need to wrap around the compiled function if we don't want
     to serialize them in particular cases.
     Right now serialization for the custom backend is done via
-    serializing the Dynamo fx graph plus example inputs.
+    serializing the Dynamo fx graph; compile inputs are re-derived from the
+    graph placeholders' ``example_value`` metadata on rebuild.
+
+    Deliberately does NOT hold the example inputs dynamo hands the backend:
+    those are the REAL first-call input tensors, and this object lives in the
+    dynamo code cache for the process lifetime, so storing them would pin the
+    whole first-call input set (multi-GB of activations for a large region).
     """
 
     def __init__(
         self,
         graph_module,
-        example_inputs,
         model_tag,
         optimized_call,
         model_idx: int = 0,
@@ -63,7 +67,6 @@ class MagiSerializableFunction(SerializableCallable):
     ):
         assert isinstance(graph_module, torch.fx.GraphModule)
         self.graph_module = graph_module
-        self.example_inputs = example_inputs
         self.model_idx = model_idx
         self.model_tag = model_tag
         self.traced_files = traced_files or []
@@ -92,14 +95,12 @@ class MagiSerializableFunction(SerializableCallable):
         patched_op_pickle = GraphNodeOpPatchUtils.make_patch_for_pickle()
 
         # Pickle under all patches
-        state["example_inputs"] = tree_map_only(torch.Tensor, lambda _: None, state["example_inputs"])
         with (
             patch.object(GraphPickler, "reducer_override", patched_reducer),
             patch.object(_NodePickleData, "__init__", patched_node_init),
             patch.object(_OpPickleData, "pickle", patched_op_pickle),
         ):
             state["graph_module"] = GraphPickler.dumps(state["graph_module"], Options(ops_filter=None))
-            state["example_inputs"] = GraphPickler.dumps(state["example_inputs"])
 
         return pickle.dumps(state)
 
@@ -125,16 +126,16 @@ class MagiSerializableFunction(SerializableCallable):
 
         state = pickle.loads(data)
 
-        # Backward compat: pop triton_kernel_info from old serialized artifacts.
+        # Backward compat: pop keys that old serialized artifacts carried.
         state.pop("triton_kernel_info", None)
+        state.pop("example_inputs", None)  # discarded unread; rebuild uses placeholder metadata
 
         fake_mode = FakeTensorMode(shape_env=ShapeEnv())
 
-        # Unpickle graph & inputs under node-level patches
+        # Unpickle the graph under node-level patches
         patched_unpickle = GraphNodePicklePatchUtils.make_patch_for_unpickle()
         with patch.object(_NodePickleData, "unpickle", patched_unpickle):
             state["graph_module"] = GraphPickler.loads(state["graph_module"], fake_mode)
-            state["example_inputs"] = GraphPickler.loads(state["example_inputs"], fake_mode)
 
         # Reconstruct CompileConfig from the serialized artifact (self-contained).
         compile_config_data = state.get("compile_config")
@@ -164,11 +165,17 @@ class MagiSerializableFunction(SerializableCallable):
         from magi_compiler.magi_backend import MagiBackend
         from magi_compiler.utils import OrderedSet
 
-        # Fill None placeholders in example_inputs with FakeTensors from graph metadata.
-        placeholder_fake_values = [
-            node.meta.get("example_value") for node in self.graph_module.graph.nodes if node.op == "placeholder"
-        ]
-        compile_inputs = [inp if inp is not None else placeholder_fake_values[i] for i, inp in enumerate(self.example_inputs)]
+        # Compile inputs come entirely from the graph placeholders' metadata:
+        # FakeTensors for tensor inputs, SymInts/scalars for the rest. Missing
+        # metadata would silently miscompile downstream, so fail loudly instead.
+        placeholders = [node for node in self.graph_module.graph.nodes if node.op == "placeholder"]
+        compile_inputs = [node.meta.get("example_value") for node in placeholders]
+        missing = [node.name for node, val in zip(placeholders, compile_inputs) if val is None]
+        if missing:
+            raise RuntimeError(
+                f"AOT rebuild: {len(missing)} graph placeholder(s) lack example_value metadata "
+                f"(e.g. {missing[:5]}); cannot reconstruct compile inputs for model_tag={self.model_tag}"
+            )
 
         fake_mode = detect_fake_mode(compile_inputs)
         magi_backend = MagiBackend(

--- a/magi_compiler/magi_backend/magi_backend.py
+++ b/magi_compiler/magi_backend/magi_backend.py
@@ -711,7 +711,6 @@ class MagiBackend:
 
         return MagiSerializableFunction(
             graph,
-            example_inputs,
             self.model_tag,
             runnable_gm,
             model_idx=self.model_idx,

--- a/magi_compiler/passes/fsdp_overlap/reorder.py
+++ b/magi_compiler/passes/fsdp_overlap/reorder.py
@@ -37,6 +37,7 @@ Handles both lowering forms: plain all_gather (1 launch / 1 wait) and coalesced
 """
 
 import hashlib
+import re
 from collections import defaultdict
 
 import torch
@@ -80,13 +81,27 @@ def _is_multi_output(snode: BaseSchedulerNode) -> bool:
     return type(node) is MultiOutput
 
 
+_SHAPE_SYM_RE = re.compile(r"\bs\d+\b")
+
+
 def _graph_fingerprint(order: list[BaseSchedulerNode]) -> str:
     """Rank-comparable digest of the snode sequence: type + op identity + output
     sizes + sorted origin fx TARGETS.  Origins are required -- a fused pointwise
     kernel is one ComputedBuffer whose class/size hide its contents (relu vs
     relu+sin look identical without them).  Targets only, not node names: names
-    carry per-rank numbering noise."""
+    carry per-rank numbering noise.
+
+    Dynamic-shape symbols in the sizes are canonicalized by first-appearance
+    order for the same reason: dynamo numbers them per rank (e.g. a traced CP
+    all_to_all output prints ``s27 + s82`` on rank 0 but ``s27 + s74`` on rank
+    1 for structurally identical graphs), so raw symbol names would flag
+    isomorphic graphs as divergent and needlessly disable the overlap."""
     h = hashlib.sha256()
+    sym_canon: dict[str, str] = {}
+
+    def _canon_syms(size_repr: str) -> str:
+        return _SHAPE_SYM_RE.sub(lambda m: sym_canon.setdefault(m.group(0), f"sym{len(sym_canon)}"), size_repr)
+
     for s in order:
         h.update(type(s).__name__.encode())
         for sub in getattr(s, "snodes", None) or (s,):
@@ -96,7 +111,7 @@ def _graph_fingerprint(order: list[BaseSchedulerNode]) -> str:
             op = getattr(n, "op_overload", None) or getattr(n, "python_kernel_name", None) or type(n).__name__
             h.update(str(op).encode())
             try:
-                h.update(repr(n.get_size()).encode())
+                h.update(_canon_syms(repr(n.get_size())).encode())
             except Exception:  # noqa: BLE001
                 pass
             origins = getattr(n, "origins", None)

--- a/magi_compiler/passes/fsdp_overlap/reorder.py
+++ b/magi_compiler/passes/fsdp_overlap/reorder.py
@@ -37,7 +37,6 @@ Handles both lowering forms: plain all_gather (1 launch / 1 wait) and coalesced
 """
 
 import hashlib
-import re
 from collections import defaultdict
 
 import torch
@@ -81,7 +80,15 @@ def _is_multi_output(snode: BaseSchedulerNode) -> bool:
     return type(node) is MultiOutput
 
 
-_SHAPE_SYM_RE = re.compile(r"\bs\d+\b")
+def _size_hint_of(sym) -> int:
+    """Rank-identical size hint for a sympy symbol (0 if unavailable, e.g. in
+    unit tests without a live Inductor graph)."""
+    try:
+        from torch._inductor.virtualized import V
+
+        return int(V.graph.sizevars.size_hint(sym, fallback=0))
+    except Exception:  # noqa: BLE001
+        return 0
 
 
 def _graph_fingerprint(order: list[BaseSchedulerNode]) -> str:
@@ -91,16 +98,27 @@ def _graph_fingerprint(order: list[BaseSchedulerNode]) -> str:
     relu+sin look identical without them).  Targets only, not node names: names
     carry per-rank numbering noise.
 
-    Dynamic-shape symbols in the sizes are canonicalized by first-appearance
-    order for the same reason: dynamo numbers them per rank (e.g. a traced CP
-    all_to_all output prints ``s27 + s82`` on rank 0 but ``s27 + s74`` on rank
-    1 for structurally identical graphs), so raw symbol names would flag
-    isomorphic graphs as divergent and needlessly disable the overlap."""
-    h = hashlib.sha256()
-    sym_canon: dict[str, str] = {}
+    """
+    import sympy
 
-    def _canon_syms(size_repr: str) -> str:
-        return _SHAPE_SYM_RE.sub(lambda m: sym_canon.setdefault(m.group(0), f"sym{len(sym_canon)}"), size_repr)
+    h = hashlib.sha256()
+    sym_canon: dict = {}  # sympy.Symbol -> canonical sympy.Symbol
+
+    def _canon_size(size) -> str:
+        dims = []
+        for d in size:
+            free = getattr(d, "free_symbols", None)
+            if not free:
+                dims.append(repr(d))
+                continue
+            fresh = [sym for sym in free if sym not in sym_canon]
+            # Name-free assignment order; symbol name only as the last-resort
+            # tie-break (see docstring: that case fails safe).
+            fresh.sort(key=lambda sym: (_size_hint_of(sym), d.count(sym), sym.name))
+            for sym in fresh:
+                sym_canon[sym] = sympy.Symbol(f"c{len(sym_canon):04d}")
+            dims.append(repr(d.xreplace(sym_canon)))
+        return "[" + ", ".join(dims) + "]"
 
     for s in order:
         h.update(type(s).__name__.encode())
@@ -111,7 +129,7 @@ def _graph_fingerprint(order: list[BaseSchedulerNode]) -> str:
             op = getattr(n, "op_overload", None) or getattr(n, "python_kernel_name", None) or type(n).__name__
             h.update(str(op).encode())
             try:
-                h.update(_canon_syms(repr(n.get_size())).encode())
+                h.update(_canon_size(n.get_size()).encode())
             except Exception:  # noqa: BLE001
                 pass
             origins = getattr(n, "origins", None)

--- a/magi_compiler/profiling/runtime_estimator.py
+++ b/magi_compiler/profiling/runtime_estimator.py
@@ -135,11 +135,18 @@ def _is_symbolic(s) -> bool:
 def _static(shape) -> tuple:
     """Cache-key shape.  MUST NOT call ``int()`` on a SymInt -- that adds an
     ``Eq(sym, value)`` guard and specializes the dynamic dim, breaking dynamic
-    shape compilation.  Symbolic dims are stringified (stable within a compile)."""
+    shape compilation.
+
+    Symbolic dims are keyed by their size hint (guard-free, see
+    ``_concrete_size``), tagged "~".  Not by ``str(s)``: dynamo names shape
+    symbols differently per rank, so symbol-name keys broke
+    ``warm_and_sync``'s cross-rank check and silently fell back to the
+    inaccurate analytical estimate.  Hints are rank-identical and stable
+    within a compile, so isomorphic kernels share one measurement."""
     out = []
     for s in shape:
         if _is_symbolic(s):
-            out.append(str(s))
+            out.append(("~", _concrete_size(s)))
         else:
             out.append(int(s))
     return tuple(out)

--- a/tests/feature_tests/test_compile_artifacts.py
+++ b/tests/feature_tests/test_compile_artifacts.py
@@ -748,7 +748,7 @@ class TestAOTIntegration:
         nodes[1].meta["example_value"] = ft_mul
         nodes[2].meta["example_value"] = ft_add
 
-        fn = MagiSerializableFunction(gm, [ft], "test_basic", lambda *a: None)
+        fn = MagiSerializableFunction(gm, "test_basic", lambda *a: None)
         data = MagiSerializableFunction.serialize_compile_artifacts(fn)
         assert isinstance(data, bytes) and len(data) > 0
 
@@ -800,7 +800,7 @@ class TestAOTIntegration:
         nodes[0].meta["example_value"] = ft
         nodes[1].meta["example_value"] = ft_out
 
-        fn = MagiSerializableFunction(gm, [ft], "test_einops", lambda *a: None)
+        fn = MagiSerializableFunction(gm, "test_einops", lambda *a: None)
         data = MagiSerializableFunction.serialize_compile_artifacts(fn)
         assert isinstance(data, bytes) and len(data) > 0
 
@@ -846,7 +846,7 @@ class TestAOTIntegration:
 
         list(gm.graph.nodes)[0].meta["example_value"] = ft
 
-        fn = MagiSerializableFunction(gm, [ft], "test_triton", lambda *a: None)
+        fn = MagiSerializableFunction(gm, "test_triton", lambda *a: None)
         data = MagiSerializableFunction.serialize_compile_artifacts(fn)
         assert isinstance(data, bytes) and len(data) > 0
 
@@ -890,7 +890,7 @@ class TestAOTIntegration:
         nodes[1].meta["example_value"] = 5
         nodes[2].meta["example_value"] = ft_sliced
 
-        fn = MagiSerializableFunction(gm, [ft, None], "test_slice", lambda *a: None)
+        fn = MagiSerializableFunction(gm, "test_slice", lambda *a: None)
         data = MagiSerializableFunction.serialize_compile_artifacts(fn)
         assert isinstance(data, bytes) and len(data) > 0
 

--- a/tests/feature_tests/test_fsdp_overlap_reorder.py
+++ b/tests/feature_tests/test_fsdp_overlap_reorder.py
@@ -70,6 +70,37 @@ def test_reorder_multi_rank():
     assert "REORDER_PASS" in p.stdout, out[-3000:]
 
 
+def test_fingerprint_canonicalizes_shape_symbols():
+    """Dynamic-shape symbol NAMES are per-rank numbering noise (rank0 may print
+    ``s27 + s82`` where rank1 prints ``s27 + s74`` for the same graph): the
+    fingerprint must canonicalize them by first appearance, while still
+    distinguishing genuinely different symbolic structure."""
+    from magi_compiler.passes.fsdp_overlap.reorder import _graph_fingerprint
+
+    class _FakeIR:
+        def __init__(self, size_repr):
+            self.op_overload = "fake.op"
+            self._size = size_repr
+            self.origins = None
+
+        def get_size(self):
+            return self._size
+
+    class _FakeSnode:
+        snodes = None
+
+        def __init__(self, size_repr):
+            self.node = _FakeIR(size_repr)
+
+    rank0 = [_FakeSnode("[s27 + s82, 6, 64]"), _FakeSnode("[1, s27 + s82, 2, 64]")]
+    rank1 = [_FakeSnode("[s27 + s74, 6, 64]"), _FakeSnode("[1, s27 + s74, 2, 64]")]
+    assert _graph_fingerprint(rank0) == _graph_fingerprint(rank1)
+
+    # Different symbolic STRUCTURE (second node uses a fresh symbol) must differ.
+    other = [_FakeSnode("[s27 + s82, 6, 64]"), _FakeSnode("[1, s99, 2, 64]")]
+    assert _graph_fingerprint(rank0) != _graph_fingerprint(other)
+
+
 @requires_cuda
 @requires_torchrun
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires >=2 GPUs")

--- a/tests/feature_tests/test_fsdp_overlap_reorder.py
+++ b/tests/feature_tests/test_fsdp_overlap_reorder.py
@@ -70,35 +70,78 @@ def test_reorder_multi_rank():
     assert "REORDER_PASS" in p.stdout, out[-3000:]
 
 
+class _FakeIR:
+    """Sizes are REAL sympy expressions, as ``node.get_size()`` returns: the
+    canonicalization must survive sympy's StrPrinter, which orders commutative
+    terms by symbol NAME -- a hand-written repr string would bypass exactly the
+    layer the bug lives in."""
+
+    def __init__(self, size):
+        self.op_overload = "fake.op"
+        self._size = size
+        self.origins = None
+
+    def get_size(self):
+        return self._size
+
+
+class _FakeSnode:
+    snodes = None
+
+    def __init__(self, size):
+        self.node = _FakeIR(size)
+
+
+def _graph(*sizes):
+    """Build a fake snode list; each size is a list of sympy exprs / ints."""
+    return [_FakeSnode(size) for size in sizes]
+
+
 def test_fingerprint_canonicalizes_shape_symbols():
-    """Dynamic-shape symbol NAMES are per-rank numbering noise (rank0 may print
-    ``s27 + s82`` where rank1 prints ``s27 + s74`` for the same graph): the
-    fingerprint must canonicalize them by first appearance, while still
-    distinguishing genuinely different symbolic structure."""
+    """Dynamic-shape symbol NAMES are per-rank numbering noise (the same
+    logical dim is s82 on rank 0 and s74 on rank 1 for the same graph): the
+    fingerprint must be invariant under symbol renaming, while still
+    distinguishing genuinely different symbolic structure.
+
+    Modeled like the real wan graph: the local-seq symbol first appears alone
+    in a placeholder-like dim, then the CP all_to_all output sums it with the
+    fresh cross-rank symbol, then downstream nodes use the fresh symbol alone.
+    """
+    import sympy
+
     from magi_compiler.passes.fsdp_overlap.reorder import _graph_fingerprint
 
-    class _FakeIR:
-        def __init__(self, size_repr):
-            self.op_overload = "fake.op"
-            self._size = size_repr
-            self.origins = None
+    def syms(*names):
+        return [sympy.Symbol(n, positive=True, integer=True) for n in names]
 
-        def get_size(self):
-            return self._size
-
-    class _FakeSnode:
-        snodes = None
-
-        def __init__(self, size_repr):
-            self.node = _FakeIR(size_repr)
-
-    rank0 = [_FakeSnode("[s27 + s82, 6, 64]"), _FakeSnode("[1, s27 + s82, 2, 64]")]
-    rank1 = [_FakeSnode("[s27 + s74, 6, 64]"), _FakeSnode("[1, s27 + s74, 2, 64]")]
+    # Same digit count (the case the string-level rename happened to handle).
+    (a0, b0), (a1, b1) = syms("s27", "s82"), syms("s27", "s74")
+    rank0 = _graph([a0, 3072], [a0 + b0, 6, 64], [b0, 64])
+    rank1 = _graph([a1, 3072], [a1 + b1, 6, 64], [b1, 64])
     assert _graph_fingerprint(rank0) == _graph_fingerprint(rank1)
 
-    # Different symbolic STRUCTURE (second node uses a fresh symbol) must differ.
-    other = [_FakeSnode("[s27 + s82, 6, 64]"), _FakeSnode("[1, s99, 2, 64]")]
-    assert _graph_fingerprint(rank0) != _graph_fingerprint(other)
+    # Digit-count crossing: sympy prints ``s27 + s174`` as ``s174 + s27``
+    # (StrPrinter sorts terms by name), so any rename applied AFTER printing
+    # sees a different first-appearance order and diverges.
+    (a2, b2) = syms("s27", "s174")
+    rank2 = _graph([a2, 3072], [a2 + b2, 6, 64], [b2, 64])
+    assert _graph_fingerprint(rank0) == _graph_fingerprint(rank2)
+
+    # Same digit count but flipped relative order: fresh symbol sorts BEFORE
+    # the shared one on one rank (s34 < s50) and AFTER it on the other.
+    (a3, b3), (a4, b4) = syms("s50", "s82"), syms("s50", "s34")
+    rank3 = _graph([a3, 3072], [a3 + b3, 6, 64], [b3, 64])
+    rank4 = _graph([a4, 3072], [a4 + b4, 6, 64], [b4, 64])
+    assert _graph_fingerprint(rank3) == _graph_fingerprint(rank4)
+
+    # Genuinely different LINKAGE must still differ: downstream node reuses the
+    # local-seq symbol instead of the cross-rank one.
+    linked_other = _graph([a0, 3072], [a0 + b0, 6, 64], [a0, 64])
+    assert _graph_fingerprint(rank0) != _graph_fingerprint(linked_other)
+
+    # Genuinely different EXPRESSION structure must differ: 2*s vs s + s'.
+    doubled = _graph([a0, 3072], [2 * a0, 6, 64], [b0, 64])
+    assert _graph_fingerprint(rank0) != _graph_fingerprint(doubled)
 
 
 @requires_cuda

--- a/tests/feature_tests/test_profiling_estimator.py
+++ b/tests/feature_tests/test_profiling_estimator.py
@@ -83,31 +83,66 @@ def test_static_concrete_dims_are_ints():
     assert _static((4, 8, 16)) == (4, 8, 16)
 
 
+class _FakeSym:
+    """Mimics a torch.SymInt: ``_is_symbolic()`` keys on having a ``.node``."""
+
+    node = object()
+
+    def __init__(self, name="s7", hint=None):
+        self._name = name
+        self.hint = hint
+
+    def __str__(self):
+        return self._name
+
+
 def test_static_symbolic_dim_keyed_by_hint():
-    """Symbolic dims key by their (rank-identical) size hint, NOT the symbol
-    name: dynamo numbers symbols per rank (s82 vs s74 for the same dim), and
-    symbol-name keys broke warm_and_sync's cross-rank key-set match on any
-    dynamic graph -> analytical-cost fallback -> exposed all-gathers."""
+    """The PRODUCTION path (live V.graph): symbolic dims key by their
+    rank-identical size hint, NOT the symbol name -- dynamo numbers symbols
+    per rank (s82 vs s74 for the same dim), and symbol-name keys broke
+    warm_and_sync's cross-rank key-set match on any dynamic graph ->
+    analytical-cost fallback -> exposed all-gathers.
 
-    class _FakeSym:
-        # mimic a SymInt: _is_symbolic() returns True for objects with a `.node`
-        node = object()
+    Two symbols sharing a hint sharing one table entry is exact, not
+    approximate: ``_measure_extern`` realizes replay inputs at these same
+    hints (``_realize_arg`` -> ``_concrete_size``), so the measured ns is a
+    pure function of (op, dtype, hint shape) -- re-measuring under a separate
+    key would produce the same value."""
+    from torch._inductor.virtualized import V
 
-        def __str__(self):
-            return "s7"
+    class _FakeSizevars:
+        def size_hint(self, sym, fallback=0):
+            return sym.hint
 
-    out = _static((_FakeSym(), 8))
-    # no live V.graph here -> _concrete_size falls back to 1; the shape of the
-    # key is what matters: ("~", <hint>) marks the dim dynamic, static dims stay
-    # plain ints (never int()'d from a SymInt, which would add a guard).
+    class _FakeGraph:
+        sizevars = _FakeSizevars()
+
+    with V.set_graph_handler(_FakeGraph()):
+        seq, tok = _FakeSym("s27", hint=4096), _FakeSym("s82", hint=2048)
+        seq_other_rank = _FakeSym("s74", hint=4096)  # same dim, renamed by rank 1
+
+        # hint reaches the key (not the fallback), tagged "~" for dynamic
+        assert _static((seq, 3072)) == (("~", 4096), 3072)
+        # different hints -> different keys: no false sharing across dims
+        assert _static((seq, 3072)) != _static((tok, 3072))
+        # same hint, different symbol NAME -> same key (the fix's purpose)
+        assert _static((seq, 3072)) == _static((seq_other_rank, 3072))
+        # a dynamic dim never collides with a static dim of the same value
+        assert _static((seq,)) != _static((4096,))
+
+
+def test_static_symbolic_dim_fallback_without_graph():
+    """DEGRADED path only (no live V.graph, e.g. bare unit tests):
+    ``_concrete_size`` falls back to 1 for every symbolic dim.  In production
+    ``_structural_key`` always runs inside Inductor scheduling where V.graph
+    is set, so this collapse never happens there -- and if it somehow did, the
+    measurement itself realizes inputs through the same fallback, so keys and
+    values degrade together."""
+    out = _static((_FakeSym("s7"), 8))
+    # the key SHAPE is what matters: ("~", <hint>) marks the dim dynamic,
+    # static dims stay plain ints (never int()'d from a SymInt -> no guard)
     assert out == (("~", 1), 8)
-
-    # two differently-named symbols with the same hint must produce equal keys
-    class _FakeSym2(_FakeSym):
-        def __str__(self):
-            return "s99"
-
-    assert _static((_FakeSym2(), 8)) == out
+    assert _static((_FakeSym("s99"), 8)) == out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/feature_tests/test_profiling_estimator.py
+++ b/tests/feature_tests/test_profiling_estimator.py
@@ -83,7 +83,12 @@ def test_static_concrete_dims_are_ints():
     assert _static((4, 8, 16)) == (4, 8, 16)
 
 
-def test_static_symbolic_dim_stringified():
+def test_static_symbolic_dim_keyed_by_hint():
+    """Symbolic dims key by their (rank-identical) size hint, NOT the symbol
+    name: dynamo numbers symbols per rank (s82 vs s74 for the same dim), and
+    symbol-name keys broke warm_and_sync's cross-rank key-set match on any
+    dynamic graph -> analytical-cost fallback -> exposed all-gathers."""
+
     class _FakeSym:
         # mimic a SymInt: _is_symbolic() returns True for objects with a `.node`
         node = object()
@@ -92,7 +97,17 @@ def test_static_symbolic_dim_stringified():
             return "s7"
 
     out = _static((_FakeSym(), 8))
-    assert out == ("s7", 8)  # symbolic -> str, static -> int (no specializing int())
+    # no live V.graph here -> _concrete_size falls back to 1; the shape of the
+    # key is what matters: ("~", <hint>) marks the dim dynamic, static dims stay
+    # plain ints (never int()'d from a SymInt, which would add a guard).
+    assert out == (("~", 1), 8)
+
+    # two differently-named symbols with the same hint must produce equal keys
+    class _FakeSym2(_FakeSym):
+        def __str__(self):
+            return "s99"
+
+    assert _static((_FakeSym2(), 8)) == out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 🗂️ PR Category
<!-- Please check the one that applies to this PR using "[x]". -->

- [ ] ✨ New Feature
- [x] 🚀 Optimization (performance, memory, etc.)
- [ ] 💥 Breaking Change
- [x] 🐛 Bug Fix
- [ ] 🛠️ Development / Refactoring
- [ ] 📚 Documentation
- [ ] 🧹 Chore (Dependencies, CI/CD, Configuration, etc.)
- [ ] 🧪 Testing

## 📝 Description
<!-- Please provide a clear description of what this PR does. -->
This PR contains two independent fixes in the compile/runtime layer, both found while profiling wan2.2 SimpleFSDP inference.

---
Fix 1 — fsdp_overlap: dynamic-shape symbol names are per-rank noise; key by structure, not name

Root cause. Dynamo allocates shape symbols from a process-local ShapeEnv counter with no cross-process coordination: the name a dynamic dim gets (s27, s82, …) depends on the order and history of symbol allocation during that rank's trace — not on the graph's structure. As long as every symbol in the graph derives from the ranks' common inputs, the names happen to match across ranks and the problem stays invisible.

A traced CP all_to_all breaks exactly this condition. Its output size is sum(output_split_sizes) — the local chunk plus the other ranks' chunk sizes. That is the one quantity in the graph not derived from local inputs, so dynamo materializes it as an additional symbol mid-trace, and where that symbol lands in each rank's private allocation history differs per rank. The all_to_all output prints s27 + s82 on rank 0 vs s27 + s74 on rank 1 for structurally identical graphs; a node-by-node fingerprint diff showed only the all_to_all and its downstream attention nodes differing.

Two cross-rank consistency checks treated these symbol names as part of the graph structure. Both are fail-safe, so instead of crashing they silently degraded, and the weight all-gathers ran fully exposed.

Changes.

 1. reorder.py::_graph_fingerprint — the pre-reorder "per-rank graphs are structurally identical" digest hashed raw size reprs; isomorphic graphs fingerprinted differently → fail-fast fired → reorder disabled entirely.
 Now canonicalizes shape symbols at the sympy-expression level, before printing. Renaming the printed string is not sound: sympy's StrPrinter orders commutative terms by default_sort_key ≈ symbol name (s27 + s82 prints as-is, but s27 + s174 prints as s174 + s27), so "first appearance in the string" is itself a function of the per-rank names being erased — digit-count crossings and same-digit relative-order flips would still diverge. Instead, a symbol → c{i:04d} map is built in a name-free order (first appearance across the node walk; within one expression, fresh symbols ordered by size hint, then occurrence count; name only as a last-resort tie-break for the fully-symmetric case, which is unobserved in practice and fails safe — overlap off, never a divergent schedule), then xreplace is applied before repr: sympy still name-sorts commutative terms, but now by canonical names that are rank-identical, and zero-padding keeps their own sort order immune to digit-count effects. What is structural is the symbols' occurrence pattern, not their names; genuinely different symbolic structure (different linkage, 2*s vs s + s') still diverges. The fingerprint test goes through real sympy printing (the previous version fed hand-written strings, bypassing the layer the bug lives in) and covers digit-crossing and order-flip cases.

2. runtime_estimator.py::_static — the profiling table's structural key stringified symbolic dims, so warm_and_sync's cross-rank key-set check failed → the whole cost table silently fell back to the analytical estimate, which overestimates matmul ~~400x here (mm: 19µs real vs 7405µs analytical) → the reorder believed one adjacent mm hides any gather and moved every launch by 2 slots, verdict "hidden", actually exposed. Now keys symbolic dims by their size hint (("~", hint)) — guard-free (no SymInt specialization), rank-identical, and isomorphic kernels keep sharing one measurement. If ranks ever see genuinely different hints, the key-set check degrades safely to analytical as before.

---
Fix 2 — Remove example_inputs from MagiSerializableFunction (multi-GB memory pin)

Root cause. MagiSerializableFunction stored the example_inputs dynamo hands the backend — which are the real first-call input tensors, not fakes. The object lives in the dynamo code cache for the process lifetime, so the entire first-call input set of every compiled region stayed pinned in GPU memory.

The tensor values were never actually consumed anywhere:

- the live call path only invokes optimized_call;
- serialize_compile_artifacts already nulled every tensor leaf before pickling;
- rebuild_backend (deserialize path) only ever saw those nulls and re-filled them from the graph placeholders' example_value metadata.

Changes.

- Drop the example_inputs constructor parameter and attribute entirely (call site in magi_backend.py updated).
- rebuild_backend now derives compile inputs purely from placeholder example_value metadata (FakeTensors for tensor inputs, SymInts/scalars for the rest), and raises a clear RuntimeError naming the offending placeholders if any lacks metadata — missing metadata would otherwise silently miscompile.
- deserialize_compile_artifacts stays backward compatible: the legacy example_inputs key in old artifacts is popped unread (same treatment as triton_kernel_info).

Verification. test_compile_artifacts.py 38/38 (constructors updated to the new signature); AOT cache end-to-end suites (test_transformer_cache_reuse, test_restart_analysis_cache, test_autograd_function_cache_flag) 4/4 — these exercise the real serialize → deserialize → rebuild_backend path across processes; weakref check confirms first-call inputs are released after compile (pinned without the fix).

---
Tests

- New: test_fingerprint_canonicalizes_shape_symbols (α-equivalence of the fingerprint).
- Updated: test_static_symbolic_dim_keyed_by_hint (hint-based keys); test_compile_artifacts.py constructors.
- Passing: reorder (3) / fsdp_overlap e2e (4) / estimator (16) / compile_artifacts (38) / AOT cache reuse (4).

---