### PR TITLE
Relax triton pin from ==3.5.0 to >=3.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ depyf
 graphviz
 pydantic-settings
 seaborn
-triton==3.5.0
+triton>=3.4.0


### PR DESCRIPTION
## Summary
- Change `triton==3.5.0` to `triton>=3.4.0` in `requirements.txt`
- The hard pin shadows the NGC-bundled `pytorch-triton` (3.4.0) when installing in PyTorch NGC containers, causing different Triton `backend_hash` values and numerically different compiled kernels — breaking compile-mode bit-exact reproducibility across images
- Since `pyproject.toml` declares no triton runtime dependency, this file is for development use only; relaxing the constraint lets the environment's existing triton be reused

## Context
When MAGI-2's Dockerfile runs `pip install -r requirements.txt` before installing MagiCompiler, `triton==3.5.0` overwrites the NGC base image's `pytorch-triton 3.4.0`. This produces a different `backend_hash` in Inductor-generated Triton kernels, leading to max ~5e-4 numerical differences in VAE encode that cascade to max ~1.78 divergence after DiT processing (chaotic amplification). The issue is absent in eager mode and only manifests in `torch.compile` mode.

## Test plan
- [x] Verify MagiCompiler imports and functions correctly with triton 3.4.0
- [ ] Rebuild MAGI-2 image without triton override, confirm compile-mode parity with Athena