### PR TITLE
feat: redirect Triton cache into magi managed cache tree

### DIFF
--- a/magi_compiler/_api.py
+++ b/magi_compiler/_api.py
@@ -25,7 +25,7 @@ from torch import distributed as dist
 from torch import nn
 from torch._dynamo.symbolic_convert import InliningInstructionTranslator
 
-from magi_compiler.config import debug_dump_path, inductor_cache_dump_path
+from magi_compiler.config import debug_dump_path, inductor_cache_dump_path, triton_cache_dump_path
 from magi_compiler.cuda.cudart import pin_memory_in_place
 from magi_compiler.magi_backend.magi_compiler_base import MagiCompileState
 from magi_compiler.utils import compilation_counter, envs, magi_logger
@@ -441,6 +441,7 @@ def _compilation_context(state: MagiCompileState):
 
     _debug_dump_path = debug_dump_path(state.compile_config.cache_root_dir, state.model_idx, state.model_tag)
     _inductor_cache_dump_path = inductor_cache_dump_path(state.compile_config.cache_root_dir)
+    _triton_cache_dump_path = triton_cache_dump_path(state.compile_config.cache_root_dir)
 
     with (
         _isolated_dynamo_config(),
@@ -449,7 +450,13 @@ def _compilation_context(state: MagiCompileState):
         patch.object(torch._dynamo.config, "force_nn_module_property_static_shapes", False),
         patch.object(torch._dynamo.config, "enable_aot_compile", True),
         _hijack_inline_call_to_collect_traced_files(state),
-        patch.dict(os.environ, {"TORCHINDUCTOR_CACHE_DIR": (_inductor_cache_dump_path).as_posix()}),
+        patch.dict(
+            os.environ,
+            {
+                "TORCHINDUCTOR_CACHE_DIR": (_inductor_cache_dump_path).as_posix(),
+                "TRITON_CACHE_DIR": (_triton_cache_dump_path).as_posix(),
+            },
+        ),
         explain_compilation(_debug_dump_path.as_posix()),
     ):
         yield

--- a/magi_compiler/config.py
+++ b/magi_compiler/config.py
@@ -428,6 +428,10 @@ def magi_cache_dump_path(cache_root_dir: str, model_idx: int, model_tag: str | N
     return Path(cache_root_dir) / "magi_cache" / model_rank_dir_name(model_idx, model_tag)
 
 
+def triton_cache_dump_path(cache_root_dir: str) -> Path:
+    return Path(cache_root_dir) / "triton_cache"
+
+
 def inductor_cache_dump_path(cache_root_dir: str, model_idx: int | None = None, model_tag: str | None = None) -> Path:
     return Path(cache_root_dir) / "inductor_cache"
 


### PR DESCRIPTION
## Summary

- Set `TRITON_CACHE_DIR` alongside `TORCHINDUCTOR_CACHE_DIR` in `_compilation_context()`, pointing to `{cache_root_dir}/triton_cache`.
- Previously Triton used its default `~/.triton/cache` which only stores `.cubin` files. With this change, all compilation artifacts (`.source`, `.ptx`, `.json`, `.cubin`) are preserved in the managed cache tree.
- Enables post-hoc analysis of autotuning decisions (e.g., inspecting multi-config reduction kernels for determinism debugging).

## Motivation

When investigating non-determinism in compiled VAE models, we needed to inspect Triton kernel source code and autotuning metadata. However, `magi_compiler` only stored `.cubin` files because `TRITON_CACHE_DIR` was not redirected into the managed tree. This PR fixes the gap.

## Changes

- `config.py`: Add `triton_cache_dump_path()` returning `{cache_root_dir}/triton_cache`
- `_api.py`: Import and use `triton_cache_dump_path`, add `TRITON_CACHE_DIR` to the env patch dict

## Test plan

- [ ] Verify `triton_cache/` directory is created under `MAGI_COMPILE_CACHE_ROOT_DIR` after compilation
- [ ] Verify `.source`, `.ptx`, `.json` artifacts are present (not just `.cubin`)
- [ ] Run existing MagiCompiler unit tests