### PR TITLE
[Fix] offload .to(cuda) interception + configurable nd_tiling max_tiles and prefetch lookahead

### DIFF
--- a/magi_compiler/_api.py
+++ b/magi_compiler/_api.py
@@ -509,6 +509,17 @@ def _patch_cpu_offload_apply(cls: type[nn.Module]):
         id_cpu_lambda = getattr(fn, "__qualname__", "") == "Module.cpu.<locals>.<lambda>"
         is_to_lambda = getattr(fn, "__qualname__", "") == "Module.to.<locals>.convert"
 
+        # Detect .to("cuda:X") by probing the lambda on a small CPU tensor.
+        # .to("cpu") also produces is_to_lambda=True but should not trigger offload.
+        is_to_cuda = False
+        if is_to_lambda and not getattr(self, "_magi_offloaded_once", False):
+            try:
+                is_to_cuda = fn(torch.empty(0, device="cpu")).is_cuda
+            except Exception:
+                pass
+
+        is_moving_to_gpu = is_cuda_lambda or is_to_cuda
+
         # after first time to call _apply(cuda), skip "Module.to" and "Module.cpu" and "Module.cuda"
         if getattr(self, "_magi_offloaded_once", False):
             if is_cuda_lambda or id_cpu_lambda or is_to_lambda:
@@ -516,8 +527,8 @@ def _patch_cpu_offload_apply(cls: type[nn.Module]):
             else:
                 return _orig_apply(self, fn)
         else:
-            # first time to call _apply(cuda), move all parameters/buffers to CPU
-            if not is_cuda_lambda:
+            # first time to call _apply(cuda) or _apply(to_cuda), move all parameters/buffers to CPU
+            if not is_moving_to_gpu:
                 return _orig_apply(self, fn)
 
         # move all parameters/buffers to CPU

--- a/magi_compiler/config.py
+++ b/magi_compiler/config.py
@@ -92,6 +92,18 @@ class PassConfig(BaseModel):
             "Env var: MAGI_COMPILE_PASS_CONFIG__ENABLE_ND_TILING_WORKAROUND (1/0/true/false)."
         ),
     )
+    nd_tiling_max_tiles: int = Field(
+        2,
+        ge=1,
+        le=3,
+        description=(
+            "max_tiles the ND-tiling workaround sets. 2 (default) is safe: Inductor's Grid2D "
+            "folds a y-grid overflow into z. 3 is experimental -- Grid3D has no z-overflow "
+            "handling, so a conv-heavy dynamic-shape graph (turbo VAE at 1080p) can exceed "
+            "CUDA's 65535 z-grid limit. "
+            "Env var: MAGI_COMPILE_PASS_CONFIG__ND_TILING_MAX_TILES."
+        ),
+    )
     enable_mm_epilogue_fusion: bool = Field(
         False,
         description=(
@@ -180,6 +192,7 @@ class OffloadConfig(BaseModel):
         OffloadPolicy.COST_EFFECTIVE, description="The policy for offloading the model to CPU."
     )
     bandwidth_safety_factor: float = Field(0.9, description="The safety factor for the H2D bandwidth.")
+    max_prefetch_lookahead: int = Field(2, description="Max layers to prefetch ahead. 0 disables prefetch to save GPU memory.")
 
 
 class FSDPConfig(BaseModel):

--- a/magi_compiler/offload/scheduler.py
+++ b/magi_compiler/offload/scheduler.py
@@ -154,7 +154,7 @@ class BaseScheduler(OffloadScheduler):
         except ValueError:
             return
 
-        max_lookahead = 2
+        max_lookahead = self.compile_config.offload_config.max_prefetch_lookahead
         target_node = None
         is_next_iter = False
 

--- a/magi_compiler/passes/piecewise_graph/nd_tiling_workaround.py
+++ b/magi_compiler/passes/piecewise_graph/nd_tiling_workaround.py
@@ -18,7 +18,6 @@
 import torch
 
 from ...magi_depyf.timeline import emit_pass_lifecycle
-from ...utils.envs import IS_PT_212
 from ..pass_base import MagiInductorPass
 
 
@@ -40,7 +39,9 @@ class ND_TilingWorkaroundPass(MagiInductorPass):
         torch._inductor.config.triton.prefer_nd_tiling = True
         torch._inductor.config.triton.tile_reductions = True
 
-        # PT 2.12 Inductor generates invalid 3D-grid reduction kernels with
-        # max_tiles=3 (program_id(2) mapped to a non-existent grid dim).
-        # Cap at 2 on PT >= 2.12 until the upstream fix lands.
-        torch._inductor.config.triton.max_tiles = 2 if IS_PT_212 else 3
+        # Capped at 2 by default: Grid3D has no z-overflow handling, so a
+        # conv-heavy dynamic-shape graph can exceed CUDA's 65535 z-grid limit.
+        # Raise it via MAGI_COMPILE_PASS_CONFIG__ND_TILING_MAX_TILES to test 3.
+        from ...config import get_compile_config
+
+        torch._inductor.config.triton.max_tiles = get_compile_config().pass_config.nd_tiling_max_tiles

--- a/tests/feature_tests/test_nd_tiling_workaround.py
+++ b/tests/feature_tests/test_nd_tiling_workaround.py
@@ -54,11 +54,10 @@ def _restore_inductor_config():
 from magi_compiler.utils.envs import IS_PT_212
 
 
-def _assert_injected(injected):
+def _assert_injected(injected, expected_max_tiles=2):
     cfg = torch._inductor.config
     if injected:
         assert cfg.triton.prefer_nd_tiling is True
-        expected_max_tiles = 2 if IS_PT_212 else 3
         assert cfg.triton.max_tiles == expected_max_tiles
         assert cfg.triton.tile_reductions is True
     else:
@@ -82,7 +81,22 @@ def test_auto_injects_when_all_conditions_met(fake_mode):
     pass_ = ND_TilingWorkaroundPass()
     gm = _auto_eligible_graph(fake_mode)
     pass_(gm.graph)
-    _assert_injected(True)
+    _assert_injected(True, expected_max_tiles=2)
+
+
+def test_auto_injects_with_version_appropriate_max_tiles(fake_mode):
+    """PT < 2.12 can safely use max_tiles=3; PT >= 2.12 must stay at 2."""
+    from magi_compiler.config import get_compile_config
+
+    safe_max = 2 if IS_PT_212 else 3
+    get_compile_config().pass_config.nd_tiling_max_tiles = safe_max
+    try:
+        pass_ = ND_TilingWorkaroundPass()
+        gm = _auto_eligible_graph(fake_mode)
+        pass_(gm.graph)
+        _assert_injected(True, expected_max_tiles=safe_max)
+    finally:
+        get_compile_config().pass_config.nd_tiling_max_tiles = 2
 
 
 def test_auto_skips_on_static_shapes(fake_mode):


### PR DESCRIPTION
## Summary

Three bug fixes and one config knob exposed during disaggregated multi-model inference on 31 GiB GPUs (RTX 5090):

1. **`_patch_cpu_offload_apply` now intercepts `.to(cuda:X)` in addition to `.cuda()`**
   - Callers using `model.to(device)` (common in multi-model pipelines) bypassed the offload hook entirely, putting all weights on GPU and OOMing on 31 GiB cards.
   - Fix: probe the `.to()` lambda with a small CPU tensor to detect CUDA target.

2. **nd_tiling max_tiles capped at 2 unconditionally**
   - max_tiles=3 overflows the CUDA z-grid limit (65535) on conv-heavy dynamic-shape graphs (e.g. 1080p VAE decode). Grid3D has no z-overflow handling.
   - Previously only guarded on PT>=2.12; now capped on all versions.

3. **max_tiles exposed as `MAGI_COMPILE_PASS_CONFIG__ND_TILING_MAX_TILES`**
   - Allows experimentation without code edits. Default remains 2.

4. **Prefetch lookahead configurable via `OffloadConfig.max_prefetch_lookahead`**
   - Hard-coded 2 layers of lookahead costs GPU memory a small card may not have. Setting to 0 disables prefetch entirely.