### PR TITLE
ci: split EVT CUTLASS tests into separate ci:evt workflow

### DIFF
--- a/.github/workflows/_ci_pipeline.yml
+++ b/.github/workflows/_ci_pipeline.yml
@@ -36,6 +36,11 @@ on:
                 description: Short label for display (e.g. pt29, pt212).
                 required: true
                 type: string
+            test-override:
+                description: If set, run ONLY this pytest path instead of the full shard matrix.
+                required: false
+                type: string
+                default: ''
         outputs:
             image_tag:
                 description: Image reference that was built.
@@ -171,7 +176,7 @@ jobs:
     #   api            – heavy torch.compile / custom-op registration
     #   feature-fsdp   – FSDP overlap (torchrun subprocess tests)
     #   feature-cache  – cache invariant / topology / artifact management
-    #   feature-pass   – inductor passes & CUTLASS fusion
+    #   feature-pass   – inductor passes (CUTLASS EVT → separate ci:evt workflow)
     #   feature-runtime– CUDA graph, symbolic shapes, profiling, offload
     #   depyf          – mostly CPU-only bytecode decompile roundtrips
 
@@ -195,7 +200,7 @@ jobs:
                 -   shard: feature-cache
                     paths: tests/feature_tests/cache/
                 -   shard: feature-pass
-                    paths: tests/feature_tests/pass/
+                    paths: tests/feature_tests/pass/ --ignore=tests/feature_tests/pass/test_matmul_epilogue_fusion.py
                 -   shard: feature-runtime
                     paths: tests/feature_tests/ tests/torch_native_tests/ --ignore=tests/feature_tests/fsdp --ignore=tests/feature_tests/cache --ignore=tests/feature_tests/pass
                 -   shard: depyf
@@ -236,4 +241,9 @@ jobs:
                 "
 
         -   name: Run ${{ matrix.shard }} tests
+            if: ${{ inputs.test-override == '' }}
             run: pytest -v ${{ matrix.paths }} --tb=short
+
+        -   name: Run override tests
+            if: ${{ inputs.test-override != '' }}
+            run: pytest -v ${{ inputs.test-override }} --tb=short

--- a/.github/workflows/evt_test.yml
+++ b/.github/workflows/evt_test.yml
@@ -1,0 +1,69 @@
+name: EVT CUTLASS Test
+
+# CUTLASS EVT epilogue-fusion tests need ~35 min of nvcc compilation
+# per PyTorch version. Triggered independently via `ci:evt` label so
+# they don't block the regular `ci:run` pipeline.
+
+on:
+    pull_request_target:
+        types: [labeled]
+        branches:
+        -   main
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    guard:
+        name: Check ci:evt label
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+        -   name: Require ci:evt label
+            run: |
+                if [ "${{ github.event.label.name }}" != "ci:evt" ]; then
+                  echo "::notice::Skipped: label is not ci:evt."
+                  exit 1
+                fi
+        -   name: Remove ci:evt label
+            uses: actions/github-script@v7
+            with:
+                script: |
+                    await github.rest.issues.removeLabel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number,
+                        name: 'ci:evt'
+                    });
+
+    pt29:
+        name: PyTorch 2.9
+        needs: guard
+        uses: ./.github/workflows/_ci_pipeline.yml
+        with:
+            kind: pr
+            workspace: /home/niubility2/cenzhiyao/ci/magi-compiler-workspaces/evt-${{ github.event.pull_request.number }}-pt29
+            head-sha: ${{ github.event.pull_request.head.sha }}
+            base-sha: ${{ github.event.pull_request.base.sha }}
+            pr-number: ${{ github.event.pull_request.number }}
+            base-image: nvcr.io/nvidia/pytorch:25.10-py3
+            pytorch-label: pt29
+            test-override: tests/feature_tests/pass/test_matmul_epilogue_fusion.py
+        secrets: inherit
+
+    pt212:
+        name: PyTorch 2.12
+        needs: guard
+        uses: ./.github/workflows/_ci_pipeline.yml
+        with:
+            kind: pr
+            workspace: /home/niubility2/cenzhiyao/ci/magi-compiler-workspaces/evt-${{ github.event.pull_request.number }}-pt212
+            head-sha: ${{ github.event.pull_request.head.sha }}
+            base-sha: ${{ github.event.pull_request.base.sha }}
+            pr-number: ${{ github.event.pull_request.number }}
+            base-image: nvcr.io/nvidia/pytorch:26.05-py3
+            pytorch-label: pt212
+            test-override: tests/feature_tests/pass/test_matmul_epilogue_fusion.py
+        secrets: inherit


### PR DESCRIPTION
CUTLASS EVT epilogue-fusion tests (`test_matmul_epilogue_fusion.py`) require ~35 min of `nvcc` compilation per PyTorch version, frequently timing out the `feature-pass` shard in regular CI.

**Changes:**
- `feature-pass` shard now excludes `test_matmul_epilogue_fusion.py`
- New `evt_test.yml` workflow triggered by `ci:evt` label
- Added `test-override` input to `_ci_pipeline.yml` for single-path test runs

**Usage:**
- `ci:run` → regular CI (fast, no EVT)
- `ci:evt` → EVT CUTLASS tests only (reuses same build + image)