### PR TITLE
[WIP] fix(ci): support fork references (user:branch) in checkout

### DIFF
--- a/.github/scripts/checkout_pr.py
+++ b/.github/scripts/checkout_pr.py
@@ -38,6 +38,20 @@ TOKEN = os.environ["GITHUB_TOKEN"]
 REPO = os.environ.get("GITHUB_REPOSITORY") or re.sub(r".*github\.com/", "", REPO_URL).removesuffix(".git")
 
 
+def _parse_fork_ref(ref: str) -> tuple[str, str] | None:
+    """Parse ``user:branch`` fork reference into ``(fork_repo, branch)``.
+
+    Returns ``None`` when *ref* is a plain SHA, tag, or branch name.
+    """
+    if ":" not in ref:
+        return None
+    user, branch = ref.split(":", 1)
+    if not user or not branch:
+        return None
+    repo_name = REPO.split("/")[-1]
+    return f"{user}/{repo_name}", branch
+
+
 def log(msg: str) -> None:
     print(f"[checkout] {msg}", flush=True)
 
@@ -54,8 +68,8 @@ def env_no_proxy() -> dict[str, str]:
 # ── tarball checkout ─────────────────────────────────────────────────
 
 
-def _curl(sha: str, dest: str) -> bool:
-    url = f"https://api.github.com/repos/{REPO}/tarball/{sha}"
+def _curl(sha: str, dest: str, repo: str | None = None) -> bool:
+    url = f"https://api.github.com/repos/{repo or REPO}/tarball/{sha}"
     for i in range(1, RETRIES + 1):
         via = "proxy" if i % 2 else "direct"
         log(f"tarball({sha[:8]}) attempt {i}/{RETRIES} via {via}")
@@ -102,23 +116,41 @@ def tarball_checkout() -> tuple[str, str] | None:
     """
     h, b = "/tmp/_head.tar.gz", "/tmp/_base.tar.gz"
     try:
-        if not _curl(HEAD_SHA, h) or not _curl(BASE_SHA, b):
+        head_ref, head_repo = HEAD_SHA, None
+        fork = _parse_fork_ref(HEAD_SHA)
+        if fork:
+            head_repo, head_ref = fork
+            log(f"fork detected: repo={head_repo}, branch={head_ref}")
+
+        if not _curl(head_ref, h, repo=head_repo):
             return None
+        if not BASE_SHA:
+            log("no BASE_SHA, skipping base tarball")
+        elif not _curl(BASE_SHA, b):
+            return None
+
         shutil.rmtree(".git", ignore_errors=True)
         sh("git init . && git config user.email ci@sandai.org && git config user.name CI")
-        for tar, msg, date in [
-            (b, f"base {BASE_SHA}", "2000-01-01T00:00:00Z"),
-            (h, f"head {HEAD_SHA}", "2000-01-02T00:00:00Z"),
-        ]:
+
+        tarballs = []
+        if BASE_SHA:
+            tarballs.append((b, f"base {BASE_SHA}", "2000-01-01T00:00:00Z"))
+        tarballs.append((h, f"head {HEAD_SHA}", "2000-01-02T00:00:00Z"))
+
+        for tar, msg, date in tarballs:
             if tar == h:
                 sh("git rm -rf . 2>/dev/null || true", check=False)
             _extract(tar)
             sh("git add -A")
             env = {**os.environ, "GIT_COMMITTER_DATE": date, "GIT_AUTHOR_DATE": date}
             sh(f'git commit --allow-empty -m "{msg}"', env=env)
-        base_l = subprocess.check_output(["git", "rev-parse", "HEAD~1"], text=True).strip()
+
         head_l = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
-        log(f"synthetic: {BASE_SHA[:8]}→{base_l[:8]}, {HEAD_SHA[:8]}→{head_l[:8]}")
+        if BASE_SHA:
+            base_l = subprocess.check_output(["git", "rev-parse", "HEAD~1"], text=True).strip()
+        else:
+            base_l = head_l
+        log(f"synthetic: base→{base_l[:8]}, head→{head_l[:8]}")
         return base_l, head_l
     finally:
         for f in (h, b):
@@ -136,15 +168,38 @@ def git_fetch_checkout() -> bool:
         sh("git init .")
     if sh(f"git remote set-url origin {REPO_URL}", check=False) != 0:
         sh(f"git remote add origin {REPO_URL}")
+
+    fork = _parse_fork_ref(HEAD_SHA)
+    if fork:
+        fork_repo, fork_branch = fork
+        fork_url = f"https://github.com/{fork_repo}.git"
+        log(f"fork fetch: {fork_url} branch={fork_branch}")
+        sh(f"git remote remove fork 2>/dev/null || true", check=False)
+        sh(f"git remote add fork {fork_url}")
+        for i in range(1, RETRIES + 1):
+            for f in glob.glob(".git/*.lock"):
+                os.remove(f)
+            log(f"fork-fetch attempt {i}/{RETRIES}")
+            proxy_flags = "" if i % 2 else "-c http.proxy= -c https.proxy="
+            env = None if i % 2 else env_no_proxy()
+            cmd = f"timeout 120 git {proxy_flags} fetch --no-tags --depth=1 fork {fork_branch}"
+            if sh(cmd, check=False, env=env) == 0:
+                sh(f"git checkout --force FETCH_HEAD && git clean -fdx")
+                return True
+            if i < RETRIES:
+                time.sleep(SLEEP)
+        return False
+
     for i in range(1, RETRIES + 1):
         for f in glob.glob(".git/*.lock"):
             os.remove(f)
         log(f"fetch attempt {i}/{RETRIES}")
+        refs_to_fetch = f"{BASE_SHA} {HEAD_SHA}" if BASE_SHA else HEAD_SHA
         if i % 2:
-            cmd = f"timeout 120 git -c http.lowSpeedLimit=100 -c http.lowSpeedTime=10 fetch --no-tags --prune --depth=1 origin {BASE_SHA} {HEAD_SHA}"
+            cmd = f"timeout 120 git -c http.lowSpeedLimit=100 -c http.lowSpeedTime=10 fetch --no-tags --prune --depth=1 origin {refs_to_fetch}"
             env = None
         else:
-            cmd = f"timeout 120 git -c http.proxy= -c https.proxy= -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch --no-tags --prune --depth=1 origin {BASE_SHA} {HEAD_SHA}"
+            cmd = f"timeout 120 git -c http.proxy= -c https.proxy= -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch --no-tags --prune --depth=1 origin {refs_to_fetch}"
             env = env_no_proxy()
         if sh(cmd, check=False, env=env) == 0:
             sh(f"git checkout --force {HEAD_SHA} && git clean -fdx && git reset --hard {HEAD_SHA}")
@@ -164,7 +219,8 @@ def main() -> None:
         base_ref, head_ref = result
         log("tarball succeeded")
     elif git_fetch_checkout():
-        base_ref, head_ref = BASE_SHA, HEAD_SHA
+        head_ref = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+        base_ref = BASE_SHA or head_ref
         log("git-fetch fallback succeeded")
     else:
         log("all methods failed")
@@ -173,7 +229,8 @@ def main() -> None:
     if out:
         with open(out, "a") as f:
             f.write(f"base_ref={base_ref}\nhead_ref={head_ref}\n")
-    sh(f"git diff --stat {base_ref} {head_ref} | tail -3")
+    if base_ref != head_ref:
+        sh(f"git diff --stat {base_ref} {head_ref} | tail -3")
     log("done")
 
 

--- a/.github/workflows/_ci_pipeline.yml
+++ b/.github/workflows/_ci_pipeline.yml
@@ -103,7 +103,13 @@ jobs:
                 git config --global user.name "CI"
 
                 script_path=".github/scripts/checkout_pr.py"
-                api_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/contents/${script_path}?ref=${HEAD_SHA}"
+                # HEAD_SHA may be a fork ref (user:branch) which is not a valid
+                # ref for the Contents API.  Try HEAD_SHA first; fall back to main.
+                script_ref="${HEAD_SHA}"
+                if [[ "$script_ref" == *:* ]]; then
+                    script_ref="refs/heads/main"
+                fi
+                api_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/contents/${script_path}?ref=${script_ref}"
 
                 mkdir -p .github/scripts
                 for attempt in $(seq 1 10); do


### PR DESCRIPTION
## 问题

workflow_dispatch 手动触发 EVT 测试时，传入 fork 引用格式 `user:branch`（如 `wtr0504:evt-compile-reuse-and-faster-tests`）作为 `head-sha`，导致 checkout 步骤 404 失败：

1. `_ci_pipeline.yml` 用 HEAD_SHA 作为 GitHub Contents API 的 ref 参数下载 `checkout_pr.py`，但 `user:branch` 不是本仓库的有效 ref
2. `checkout_pr.py` 的 tarball 下载和 git fetch 都假设 HEAD_SHA 是本仓库的 SHA/branch，无法处理 fork 引用

## 修复

- `_ci_pipeline.yml`：检测到 fork 引用（含冒号）时，fallback 到 `refs/heads/main` 下载 checkout 脚本
- `checkout_pr.py`：新增 `_parse_fork_ref()` 解析 `user:branch` 为 `(fork_repo, branch)`；tarball 从 fork 仓库下载；git-fetch 添加 fork 作为独立 remote；兼容 BASE_SHA 为空的场景